### PR TITLE
[feat] 가계부 CRUD 기능 완료

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -28,6 +28,7 @@
     "react-chartjs-2": "^5.3.1",
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.9"
   },

--- a/fe/src/app/(app)/history/layout.tsx
+++ b/fe/src/app/(app)/history/layout.tsx
@@ -5,7 +5,6 @@ export default function RootLayout({
 }>) {
   return (
     <>
-    layout
     {children}
     </>
   );

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -4,7 +4,7 @@ export default function page() {
   return(
       <>
           <TransactionList/>
-          {/* <TransactionSubmitForm/> */}
+          <TransactionSubmitForm/>
       </>
   )
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -48,7 +48,7 @@ export default function Page() {
   return(
       <div className="relative flex h-screen overflow-hidden">
         <div className="flex-1 overflow-auto">
-          <TransactionList key={refreshKey} onSelectTransaction={handleSelectTransaction} />
+          <TransactionList refreshKey={refreshKey} onSelectTransaction={handleSelectTransaction} />
           
           <Button
             onClick={handleCreateNew}

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -4,7 +4,8 @@ export default function page() {
   return(
       <>
           <TransactionList/>
-          {/* <TransactionSubmitForm/> */}
+          <TransactionSubmitForm mode='create'/>
+          <TransactionSubmitForm mode='edit'/>
       </>
   )
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -22,6 +22,14 @@ export default function Page() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [formMode, setFormMode] = useState<'create' | 'edit'>('create')
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | undefined>()
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const handleSelectTransaction = (transaction: Transaction) => {
+    console.log(transaction)
+    setSelectedTransaction(transaction)
+    setFormMode('edit')
+    setIsSidebarOpen(true)
+  }
 
   const handleCreateNew = () => {
     setSelectedTransaction(undefined)
@@ -33,10 +41,14 @@ export default function Page() {
     setIsSidebarOpen(false)
   }
 
+  const handleSuccess = () => {
+    setRefreshKey(prev => prev + 1)
+  }
+
   return(
       <div className="relative flex h-screen overflow-hidden">
         <div className="flex-1 overflow-auto">
-          <TransactionList />
+          <TransactionList key={refreshKey} onSelectTransaction={handleSelectTransaction} />
           
           <Button
             onClick={handleCreateNew}
@@ -65,6 +77,7 @@ export default function Page() {
             mode={formMode}
             transaction={selectedTransaction}
             onClose={handleClose}
+            onSuccess={handleSuccess}
           />
         </div>
     </div>

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -3,9 +3,8 @@ import { TransactionList } from "@/components/transaction/TransactionList"
 export default function page() {
   return(
       <>
-          <div>calendar</div>
-          <TransactionSubmitForm/>
           <TransactionList/>
+          {/* <TransactionSubmitForm/> */}
       </>
   )
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -1,11 +1,72 @@
+'use client'
+import { useState } from "react"
 import TransactionSubmitForm from "@/components/transaction/TransactionSubmitForm"
 import { TransactionList } from "@/components/transaction/TransactionList"
-export default function page() {
+import { Button } from "@/components/ui/button"
+import { Plus } from "lucide-react"
+interface Transaction {
+  id: string
+  title: string
+  user_id: string
+  category_id: string
+  type: 'income' | 'expense'
+  date: string
+  amount: number
+  fixed_rule_id: string | null
+  memo: string | null
+  created_at: Date
+  updated_at: Date
+  tags: string[]
+}
+export default function Page() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create')
+  const [selectedTransaction, setSelectedTransaction] = useState<Transaction | undefined>()
+
+  const handleCreateNew = () => {
+    setSelectedTransaction(undefined)
+    setFormMode('create')
+    setIsSidebarOpen(true)
+  }
+
+  const handleClose = () => {
+    setIsSidebarOpen(false)
+  }
+
   return(
-      <>
-          <TransactionList/>
-          <TransactionSubmitForm mode='create'/>
-          <TransactionSubmitForm mode='edit'/>
-      </>
+      <div className="relative flex h-screen overflow-hidden">
+        <div className="flex-1 overflow-auto">
+          <TransactionList />
+          
+          <Button
+            onClick={handleCreateNew}
+            className="fixed bottom-6 right-6 rounded-full w-14 h-14 md:bottom-8 md:right-8 z-30"
+            size="icon"
+          >
+            <Plus/>
+          </Button>
+        </div>
+
+        {/* moblie */}
+        {isSidebarOpen && (
+          <div 
+            className="fixed bg-black z-20 md:hidden"
+            onClick={handleClose}
+          />
+        )}
+
+        <div
+          className={`fixed right-0 top-0 h-full bg-white z-10 w-full md:w-96
+            ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'}
+            border-l shadow-2xl
+          `}
+        >
+          <TransactionSubmitForm
+            mode={formMode}
+            transaction={selectedTransaction}
+            onClose={handleClose}
+          />
+        </div>
+    </div>
   )
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -46,40 +46,30 @@ export default function Page() {
   }
 
   return(
-      <div className="relative flex h-screen overflow-hidden">
-        <div className="flex-1 overflow-auto">
-          <TransactionList refreshKey={refreshKey} onSelectTransaction={handleSelectTransaction} />
-          
-          <Button
-            onClick={handleCreateNew}
-            className="fixed bottom-6 right-6 rounded-full w-14 h-14 md:bottom-8 md:right-8 z-30"
-            size="icon"
-          >
-            <Plus/>
-          </Button>
-        </div>
+      <>
+        <div className="flex w-full h-screen overflow-hidden border-2">
+          <div className="flex-1 overflow-auto">
+            <Button
+              onClick={handleCreateNew}
+              className="rounded-full w-12 h-12 z-50 mr-4"
+              size="icon"
+            >
+              <Plus/>
+            </Button>
+            <TransactionList refreshKey={refreshKey} onSelectTransaction={handleSelectTransaction} />
+          </div>
 
-        {/* moblie */}
-        {isSidebarOpen && (
-          <div 
-            className="fixed bg-black z-20 md:hidden"
-            onClick={handleClose}
-          />
-        )}
-
-        <div
-          className={`fixed right-0 top-0 h-full bg-white z-10 w-full md:w-96
-            ${isSidebarOpen ? 'translate-x-0' : 'translate-x-full'}
-            border-l shadow-2xl
-          `}
-        >
-          <TransactionSubmitForm
-            mode={formMode}
-            transaction={selectedTransaction}
-            onClose={handleClose}
-            onSuccess={handleSuccess}
-          />
+          {isSidebarOpen && (
+            <div className="w-96 border-l shadow-2xl overflow-auto bg-white">
+              <TransactionSubmitForm
+                mode={formMode}
+                transaction={selectedTransaction}
+                onClose={handleClose}
+                onSuccess={handleSuccess}
+              />
+            </div>
+          )}
         </div>
-    </div>
+      </>
   )
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -4,7 +4,7 @@ export default function page() {
   return(
       <>
           <TransactionList/>
-          <TransactionSubmitForm/>
+          {/* <TransactionSubmitForm/> */}
       </>
   )
 }

--- a/fe/src/app/(app)/layout.tsx
+++ b/fe/src/app/(app)/layout.tsx
@@ -1,7 +1,7 @@
 import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
 import Navigation from '@/components/layout/Navigation';
-
+import { Toaster } from 'sonner';
 const AppLayout = ({
   children,
 }: Readonly<{
@@ -16,6 +16,7 @@ const AppLayout = ({
         <main className="flex flex-1 items-center justify-center md:pl-28">
           {children}
         </main>
+        <Toaster/>
       </div>
 
       <Footer />

--- a/fe/src/components/transaction/TransactionList.tsx
+++ b/fe/src/components/transaction/TransactionList.tsx
@@ -28,6 +28,11 @@ interface Transaction {
   tags : string[]
 }
 
+interface TransactionListProps {
+  onSelectTransaction: (transaction: Transaction) => void
+  refreshKey?: number
+}
+
 const dummyTransactions = [
   { title:'점심 식사', category_id: 'cat-001', type: 'expense', date: '2024-12-23', amount: 15000 },
   { title:'출/퇴근 교통비', category_id: 'cat-002', type: 'expense', date: '2024-12-22', amount: 3500 },
@@ -39,8 +44,7 @@ const dummyTransactions = [
 ]
 
 
-export const TransactionList = () => {
-
+export const TransactionList = ({ onSelectTransaction, refreshKey }: TransactionListProps ) => {
     const [transactions, setTransactions] = useState<Transaction[]>([]);
 
     useEffect(()=>{
@@ -61,7 +65,7 @@ export const TransactionList = () => {
             }
         }
         fetchTransactions();
-    },[])
+    },[refreshKey])
 
 
 
@@ -80,7 +84,7 @@ export const TransactionList = () => {
                     </div>
                     <ItemTitle className="p-2 text-left">{e.title}</ItemTitle>
                     <ItemActions className="ml-auto">
-                        <Button className="cursor-pointer" size="sm">
+                        <Button className="cursor-pointer" size="sm" onClick={()=>onSelectTransaction(e)}>
                             <ChevronRight/>
                         </Button>
                     </ItemActions>

--- a/fe/src/components/transaction/TransactionList.tsx
+++ b/fe/src/components/transaction/TransactionList.tsx
@@ -71,7 +71,7 @@ export const TransactionList = ({ onSelectTransaction, refreshKey }: Transaction
 
 
     return (
-        <div className="space-y-6 max-w-md mx-auto p-6">
+        <div className="min-h-screen space-y-6 w-full max-w-lg mx-auto p-4 md:p-6 lg:p-8">
             <Label className="text-xl">가계부</Label>
             {transactions.map((e,index)=>(
             <Item variant="outline" key={index}>

--- a/fe/src/components/transaction/TransactionList.tsx
+++ b/fe/src/components/transaction/TransactionList.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -10,6 +10,23 @@ import {
   ItemContent,
   ItemTitle,
 } from "@/components/ui/item"
+import { toast } from "sonner"
+import { supabase } from "@/utils/supabase/client"
+
+interface Transaction {
+  id: string
+  title: string
+  user_id : string
+  category_id: string
+  type: 'income' | 'expense'
+  date: string
+  amount: number
+  fixed_rule_id : string|null
+  memo : string | null
+  created_at : Date
+  updated_at : Date
+  tags : string[]
+}
 
 const dummyTransactions = [
   { title:'점심 식사', category_id: 'cat-001', type: 'expense', date: '2024-12-23', amount: 15000 },
@@ -23,10 +40,36 @@ const dummyTransactions = [
 
 
 export const TransactionList = () => {
+
+    const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+    useEffect(()=>{
+        const fetchTransactions = async()=>{
+            try{
+                const {data:{user}, error: authError } = await supabase.auth.getUser();
+                if(!user||authError ){
+                    toast.warning('로그인이 필요합니다')
+                    return;
+                }
+                const {data, error} = await supabase.from('transactions')
+                .select('*')
+                .eq('user_id',user.id)
+
+                setTransactions(data || [])
+            }catch(err){
+                toast('데이터를 불러오는 데 실패했습니다')
+            }
+        }
+        fetchTransactions();
+    },[])
+
+
+
+
     return (
         <div className="space-y-6 max-w-md mx-auto p-6">
             <Label className="text-xl">가계부</Label>
-            {dummyTransactions.map((e,index)=>(
+            {transactions.map((e,index)=>(
             <Item variant="outline" key={index}>
                 <ItemContent className="flex flex-row items-center">
                     <div className="flex flex-col gap-1 w-24">

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -46,45 +46,43 @@ export default function TransactionSubmitForm() {
     }
 
     const validateFormData =()=>{
-        setError(null);
-
         if(!title.trim()){
-            setError("제목을 입력해주세요");
-            return false;
+            const errorMsg = "제목을 입력해주세요";
+            return errorMsg;
         }else if(title.trim().length>20){
-            setError("제목은 20자 이내로  입력해주세요")
-            return false;
+            const errorMsg = "제목은 20자 이내로  입력해주세요"
+            return errorMsg;
         }
 
         if(!transactionType){
-            setError("거래 유형을 선택해주세요");
-            return false;
+            const errorMsg = "거래 유형을 선택해주세요";
+            return errorMsg;
         }
 
         if(!category){
-            setError("카테고리를 선택해주세요");
-            return false;
+            const errorMsg = "카테고리를 선택해주세요";
+            return errorMsg;
         }
 
         if(!amount || Number(amount)<=0){
-            setError("금액은 0보다 커야 합니다")
-            return false;
+            const errorMsg = "금액은 0보다 커야 합니다"
+            return errorMsg;
         }
-        return true;
+        return null;
 
     }
     const handleSubmit = async(e: React.FormEvent)=>{
         e.preventDefault();
 
-        if (!validateFormData()) {
-            console.log(error)
-            toast.warning(error)
+        const errorMsg = validateFormData();
+        if (errorMsg) {
+            toast.warning(errorMsg)
             return
         }
         try{
             const {data:{user}, error: authError } = await supabase.auth.getUser();
             if(!user||authError ){
-                console.log("로그인이 필요합니다")
+                toast.warning('로그인이 필요합니다')
             }
             const formattedDate = date.toISOString().split('T')[0]
 
@@ -104,7 +102,7 @@ export default function TransactionSubmitForm() {
                 console.log(data)
                 if (error) {
                     console.error('Insert error:', error)
-                    alert("저장 실패: " + error.message)
+                    toast.warning("저장 실패 \n" + error.message)
                     return
                 }
 

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -35,8 +35,8 @@ interface Transaction {
 interface TransactionsSubmitFormProps {
     mode : 'create' | 'edit'
     transaction? : Transaction
-    onClose? : ()=> void
-    onSuccess? : ()=> void
+    onClose : ()=> void
+    onSuccess : ()=> void
 }
 const CATEGORIES = [
     { id: "3de48bfe-69d9-4dbb-9a5d-ecdb807212f2", name: "식비", type: "expense" },
@@ -53,33 +53,41 @@ export default function TransactionSubmitForm({
     mode, transaction, onClose, onSuccess
 } : TransactionsSubmitFormProps) {
 
-    const getInitialFormData = () => {
-        if (mode === 'edit' && transaction) {
-            return {
-                title: transaction.title,
-                transactionType: transaction.type,
-                amount: transaction.amount.toString(),
-                date: new Date(transaction.date),
-                category: transaction.category_id,
-                tags: transaction.tags || []
-            }
-        }
-        return {
+    const [formData, setFormData] = useState({
             title: "",
             transactionType: "",
             amount: "",
             date: new Date(),
             category: "",
             tags: [] as string[]
-        }
-    }
-    const [formData, setFormData] = useState(getInitialFormData())
+    })
 
     const [categoryOpen, setCategoryOpen] = useState(false)
     const [tagInput, setTagInput] = useState<string>("")
     const [error, setError]= useState<string | null>();
 
-    
+    useEffect(() => {
+        if (mode === 'edit' && transaction) {
+            setFormData({
+                title: transaction.title,
+                transactionType: transaction.type,
+                amount: transaction.amount.toString(),
+                date: new Date(transaction.date),
+                category: transaction.category_id,
+                tags: transaction.tags || []
+            })
+        } else {
+            // create 모드일 때는 초기화
+            setFormData({
+                title: "",
+                transactionType: "",
+                amount: "",
+                date: new Date(),
+                category: "",
+                tags: []
+            })
+        }
+    }, [mode, transaction])
     const formatDate = (date: Date) => {
         const year = date.getFullYear()
         const month = date.getMonth() + 1
@@ -124,29 +132,44 @@ export default function TransactionSubmitForm({
             const {data:{user}, error: authError } = await supabase.auth.getUser();
             if(!user||authError ){
                 toast.warning('로그인이 필요합니다')
+                return
             }
             const formattedDate = formData.date.toISOString().split('T')[0]
 
-            const { data, error } = await supabase
-                .from('transactions')
-                .insert({
-                    user_id: user?.id,
-                    title: formData.title.trim(),
-                    type: formData.transactionType,
-                    amount: Number(formData.amount),
-                    date: formattedDate,
-                    category_id: formData.category,
-                    tags: formData.tags.length > 0 ? formData.tags : null
-                })
-                .select()
+            const transactionData = {
+                user_id: user.id,
+                title: formData.title.trim(),
+                type: formData.transactionType,
+                amount: Number(formData.amount),
+                date: formattedDate,
+                category_id: formData.category,
+                tags: formData.tags.length > 0 ? formData.tags : null
+            }
 
-                if (error) {
-                    console.error('Insert error:', error)
-                    toast.warning("저장 실패 \n" + error.message)
+            if (mode === 'create') {
+                const { error } = await supabase
+                    .from('transactions')
+                    .insert(transactionData)
+                    .select()
+
+                if(error) {
+                    toast.warning("저장 실패")
                     return
                 }
 
-            toast("가계부 작성을 완료했습니다")
+                toast.success("가계부 작성을 완료했습니다")
+            } else {
+                const { error } = await supabase
+                    .from('transactions')
+                    .update(transactionData)
+                    .eq('id', transaction!.id)
+
+                if (error) {
+                    toast.warning("수정 실패")
+                    return
+                }
+                toast.success("가계부 수정을 완료했습니다")
+            }
 
             setFormData({
                 title: "",
@@ -158,7 +181,8 @@ export default function TransactionSubmitForm({
             })
             setTagInput("")
             setError(null)
-
+            onSuccess()
+            onClose()
         }catch(error){
             console.log('error')
         }

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -111,9 +111,9 @@ export default function TransactionSubmitForm({
     }
     const handleSubmit = async(e: React.FormEvent)=>{
         e.preventDefault();
-
         const errorMsg = validateFormData();
         if (errorMsg) {
+            toast(errorMsg)
             return
         }
         try{

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -99,7 +99,6 @@ export default function TransactionSubmitForm() {
                 })
                 .select()
 
-                console.log(data)
                 if (error) {
                     console.error('Insert error:', error)
                     toast.warning("저장 실패 \n" + error.message)
@@ -107,6 +106,15 @@ export default function TransactionSubmitForm() {
                 }
 
             alert("거래 내역이 저장되었습니다")
+
+            setTitle("")
+            setTransactionType("")
+            setAmount("")
+            setCategory("")
+            setDate(new Date())
+            setTagInput("")
+            setTags([])
+            setError(null)
 
         }catch(error){
             console.log('error')

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -251,7 +251,7 @@ export default function TransactionSubmitForm({
                 <div className="grid grid-cols-2 gap-4">
                     <button
                         type="button"
-                        onClick={() => setFormData(prev => ({...prev, transactionType: 'income'}))}
+                        onClick={() => setFormData(prev => ({...prev, category:"", transactionType: 'income'}))}
                         className={cn(
                             "px-6 py-3 rounded-lg border-2 transition-all font-medium cursor-pointer",
                             formData.transactionType === 'income'
@@ -263,7 +263,7 @@ export default function TransactionSubmitForm({
                     </button>
                     <button
                         type="button"
-                        onClick={() => setFormData(prev => ({...prev, transactionType: 'expense'}))}
+                        onClick={() => setFormData(prev => ({...prev, category:"", transactionType: 'expense'}))}
                         className={cn(
                             "px-6 py-3 rounded-lg border-2 transition-all font-medium cursor-pointer",
                             formData.transactionType === 'expense'

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 import { Input } from "../ui/input"
 import { Calendar } from "@/components/ui/calendar"
 import { Button } from "../ui/button"
+import { supabase } from "@/utils/supabase/client"
 CalendarIcon
 import {
   Popover,
@@ -14,16 +15,16 @@ import {
 import { CalendarIcon } from "lucide-react"
 import { X } from "lucide-react"
 
-const DUMMY_CATEGORIES = [
-    "식비",
-    "의료비",
-    "쇼핑",
-    "교통비",
-    "공과금",
-    "월세",
-    "이자",
-    "송금",
-    "기타"
+const CATEGORIES = [
+    { id: "3de48bfe-69d9-4dbb-9a5d-ecdb807212f2", name: "식비", type: "expense" },
+    { id: "fd66cd8e-83bc-4720-8d71-34046524a849", name: "의료비", type: "expense" },
+    { id: "d9f8e176-2594-4a5c-a089-d6cae2fd97ff", name: "쇼핑", type: "expense" },
+    { id: "2f7b8dc5-9c32-4065-ac70-0edc3a02502c", name: "주거비", type: "expense" },
+    { id: "0f93d6d5-5fd0-416a-b9b0-2e42539c0ad9", name: "교통비", type: "expense" },
+    { id: "bee38c89-2393-4f72-8d77-314ca2b9c7e6", name: "문화생활", type: "expense" },
+    { id: "92a9dabd-ca15-420e-be12-2b34ab37dfb3", name: "통신비", type: "expense" },
+    { id: "94b763c9-48cd-4435-b21b-d93a41dd49da", name: "교육비", type: "expense" },
+    { id: "fb48697f-5cae-41e3-869b-0c4922523955", name: "기타", type: "expense" }
 ]
 export default function TransactionSubmitForm() {
     const [title, setTitle] = useState<string>("")
@@ -42,8 +43,41 @@ export default function TransactionSubmitForm() {
         return `${year}년 ${month}월 ${day}일`
     }
 
-    const handleSubmit = ()=>{
-        console.log('submit')
+    const handleSubmit = async(e: React.FormEvent)=>{
+        e.preventDefault();
+
+        try{
+            const {data:{user}, error: authError } = await supabase.auth.getUser();
+            if(!user||authError ){
+                console.log("로그인이 필요합니다")
+            }
+            const formattedDate = date.toISOString().split('T')[0]
+
+            const { data, error } = await supabase
+                .from('transactions')
+                .insert({
+                    user_id: user?.id,
+                    title: title.trim(),
+                    type: transactionType,
+                    amount: Number(amount),
+                    date: formattedDate,
+                    category_id: category,
+                    tags: tags.length > 0 ? tags : null
+                })
+                .select()
+
+                console.log(data)
+                if (error) {
+                    console.error('Insert error:', error)
+                    alert("저장 실패: " + error.message)
+                    return
+                }
+
+            alert("거래 내역이 저장되었습니다")
+
+        }catch(error){
+            console.log('error')
+        }
     }
 
     const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -160,12 +194,12 @@ export default function TransactionSubmitForm() {
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
                         <div className="grid grid-cols-3">
-                            {DUMMY_CATEGORIES.map((e,index)=>(
+                            {CATEGORIES.map((cat)=>(
                                 <div
                                     onClick={()=>{
-                                        setCategory(e)
+                                        setCategory(cat.id)
                                         setCategoryOpen(false)}}
-                                    className="text-center w-16 h-16 cursor-pointer" key={index}>{e}</div>
+                                    className="text-center w-16 h-16 cursor-pointer" key={cat.id}>{cat.name}</div>
                             ))}
                         </div>
                     </PopoverContent>

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { Input } from "../ui/input"
@@ -16,6 +16,27 @@ import {
 import { CalendarIcon } from "lucide-react"
 import { X } from "lucide-react"
 
+interface Transaction {
+  id: string
+  title: string
+  user_id : string
+  category_id: string
+  type: 'income' | 'expense'
+  date: string
+  amount: number
+  fixed_rule_id : string|null
+  memo : string | null
+  created_at : Date
+  updated_at : Date
+  tags : string[]
+}
+
+interface TransactionsSubmitFormProps {
+    mode : 'create' | 'edit'
+    transaction? : Transaction
+    onClose : ()=> void
+    onSuccess : ()=> void
+}
 const CATEGORIES = [
     { id: "3de48bfe-69d9-4dbb-9a5d-ecdb807212f2", name: "식비", type: "expense" },
     { id: "fd66cd8e-83bc-4720-8d71-34046524a849", name: "의료비", type: "expense" },
@@ -27,15 +48,19 @@ const CATEGORIES = [
     { id: "94b763c9-48cd-4435-b21b-d93a41dd49da", name: "교육비", type: "expense" },
     { id: "fb48697f-5cae-41e3-869b-0c4922523955", name: "기타", type: "expense" }
 ]
-export default function TransactionSubmitForm() {
-    const [title, setTitle] = useState<string>("")
-    const [transactionType, setTransactionType] = useState<string>("")
-    const [amount, setAmount] = useState<string>("")
-    const [date, setDate] = useState<Date>(new Date())
-    const [category, setCategory] = useState<string>("")
+export default function TransactionSubmitForm({
+    mode, transaction, onClose, onSuccess
+} : TransactionsSubmitFormProps) {
+    const [formData, setFormData] = useState({
+        title: "",
+        transactionType: "",
+        amount: "",
+        date: new Date(),
+        category: "",
+        tags: [] as string[]
+    })
     const [categoryOpen, setCategoryOpen] = useState(false)
     const [tagInput, setTagInput] = useState<string>("")
-    const [tags, setTags] = useState<string[]>([])
     const [error, setError]= useState<string | null>();
 
     const formatDate = (date: Date) => {
@@ -46,25 +71,25 @@ export default function TransactionSubmitForm() {
     }
 
     const validateFormData =()=>{
-        if(!title.trim()){
+        if(!formData.title.trim()){
             const errorMsg = "제목을 입력해주세요";
             return errorMsg;
-        }else if(title.trim().length>20){
+        }else if(formData.title.trim().length>20){
             const errorMsg = "제목은 20자 이내로  입력해주세요"
             return errorMsg;
         }
 
-        if(!transactionType){
+        if(!formData.transactionType){
             const errorMsg = "거래 유형을 선택해주세요";
             return errorMsg;
         }
 
-        if(!category){
+        if(!formData.category){
             const errorMsg = "카테고리를 선택해주세요";
             return errorMsg;
         }
 
-        if(!amount || Number(amount)<=0){
+        if(!formData.amount || Number(formData.amount)<=0){
             const errorMsg = "금액은 0보다 커야 합니다"
             return errorMsg;
         }
@@ -76,7 +101,6 @@ export default function TransactionSubmitForm() {
 
         const errorMsg = validateFormData();
         if (errorMsg) {
-            toast.warning(errorMsg)
             return
         }
         try{
@@ -84,18 +108,18 @@ export default function TransactionSubmitForm() {
             if(!user||authError ){
                 toast.warning('로그인이 필요합니다')
             }
-            const formattedDate = date.toISOString().split('T')[0]
+            const formattedDate = formData.date.toISOString().split('T')[0]
 
             const { data, error } = await supabase
                 .from('transactions')
                 .insert({
                     user_id: user?.id,
-                    title: title.trim(),
-                    type: transactionType,
-                    amount: Number(amount),
+                    title: formData.title.trim(),
+                    type: formData.transactionType,
+                    amount: Number(formData.amount),
                     date: formattedDate,
-                    category_id: category,
-                    tags: tags.length > 0 ? tags : null
+                    category_id: formData.category,
+                    tags: formData.tags.length > 0 ? formData.tags : null
                 })
                 .select()
 
@@ -105,15 +129,17 @@ export default function TransactionSubmitForm() {
                     return
                 }
 
-            alert("거래 내역이 저장되었습니다")
+            toast("가계부 작성을 완료했습니다")
 
-            setTitle("")
-            setTransactionType("")
-            setAmount("")
-            setCategory("")
-            setDate(new Date())
+             setFormData({
+                title: "",
+                transactionType: "",
+                amount: "",
+                date: new Date(),
+                category: "",
+                tags: []
+            })
             setTagInput("")
-            setTags([])
             setError(null)
 
         }catch(error){
@@ -130,14 +156,20 @@ export default function TransactionSubmitForm() {
     
     const addTag = () => {
         const trimmedTag = tagInput.trim()
-        if (trimmedTag && !tags.includes(trimmedTag)) {
-            setTags([...tags, trimmedTag])
+        if (trimmedTag && !formData.tags.includes(trimmedTag)) {
+            setFormData(prev => ({
+                ...prev,
+                tags: [...prev.tags, trimmedTag]
+            }))
             setTagInput("")
         }
     }
     
     const removeTag = (tagToRemove: string) => {
-        setTags(tags.filter(tag => tag !== tagToRemove))
+        setFormData(prev => ({
+            ...prev,
+            tags: prev.tags.filter(tag => tag !== tagToRemove)
+        }))
     }
     return (
         <form onSubmit={handleSubmit} className="space-y-6 max-w-md mx-auto p-6">
@@ -149,8 +181,8 @@ export default function TransactionSubmitForm() {
                     id="amount"
                     type="text"
                     placeholder="어떤 지출인가요"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
+                    value={formData.title}
+                    onChange={(e) => setFormData(prev => ({...prev, title: e.target.value}))}
                 />
             </div>
 
@@ -160,10 +192,10 @@ export default function TransactionSubmitForm() {
                 <div className="grid grid-cols-2 gap-4">
                     <button
                         type="button"
-                        onClick={() => setTransactionType('income')}
+                        onClick={() => setFormData(prev => ({...prev, transactionType: 'income'}))}
                         className={cn(
                             "px-6 py-3 rounded-lg border-2 transition-all font-medium cursor-pointer",
-                            transactionType === 'income'
+                            formData.transactionType === 'income'
                                 ? "border-gray-500"
                                 : "border-gray-300 hover:border-gray-400"
                         )}
@@ -172,10 +204,10 @@ export default function TransactionSubmitForm() {
                     </button>
                     <button
                         type="button"
-                        onClick={() => setTransactionType('expense')}
+                        onClick={() => setFormData(prev => ({...prev, transactionType: 'expense'}))}
                         className={cn(
                             "px-6 py-3 rounded-lg border-2 transition-all font-medium cursor-pointer",
-                            transactionType === 'expense'
+                            formData.transactionType === 'expense'
                                 ? "border-gray-500"
                                 : "border-gray-300 hover:border-gray-400"
                         )}
@@ -192,8 +224,8 @@ export default function TransactionSubmitForm() {
                     id="amount"
                     type="number"
                     placeholder="금액을 입력하세요"
-                    value={amount}
-                    onChange={(e) => setAmount(e.target.value)}
+                    value={formData.amount}
+                    onChange={(e) => setFormData(prev => ({...prev, amount: e.target.value}))}
                     min="0"
                 />
             </div>
@@ -209,14 +241,14 @@ export default function TransactionSubmitForm() {
                             className="w-full justify-start text-left font-normal"
                         >
                             <CalendarIcon className="mr-2 h-4 w-4" />
-                            {formatDate(date)}
+                            {formatDate(formData.date)}
                         </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
                         <Calendar
                             mode="single"
-                            selected={date}
-                            onSelect={(newDate) => newDate && setDate(newDate)}
+                            selected={formData.date}
+                            onSelect={(newDate) => newDate && setFormData(prev => ({...prev, date: newDate}))}
                         />
                     </PopoverContent>
                 </Popover>
@@ -238,14 +270,14 @@ export default function TransactionSubmitForm() {
                             {CATEGORIES.map((cat)=>(
                                 <div
                                     onClick={()=>{
-                                        setCategory(cat.id)
+                                        setFormData(prev => ({...prev, category: cat.id}))
                                         setCategoryOpen(false)}}
                                     className="text-center w-16 h-16 cursor-pointer" key={cat.id}>{cat.name}</div>
                             ))}
                         </div>
                     </PopoverContent>
                 </Popover>
-                <div>{category}</div>
+                <div>{formData.category}</div>
 
                 {/* 태그 */}
                 <div className="space-y-2">
@@ -268,9 +300,9 @@ export default function TransactionSubmitForm() {
                         추가
                     </Button>
                 </div>
-                {tags.length > 0 && (
+                {formData.tags.length > 0 && (
                     <div className="flex flex-wrap gap-2 mt-2">
-                        {tags.map((tag, index) => (
+                        {formData.tags.map((tag, index) => (
                             <div
                                 key={index}
                                 className="bg-gray-100 px-3 py-1 rounded-full flex items-center gap-2 text-sm"

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -6,6 +6,7 @@ import { Input } from "../ui/input"
 import { Calendar } from "@/components/ui/calendar"
 import { Button } from "../ui/button"
 import { supabase } from "@/utils/supabase/client"
+import { toast } from "sonner"
 CalendarIcon
 import {
   Popover,
@@ -75,6 +76,11 @@ export default function TransactionSubmitForm() {
     const handleSubmit = async(e: React.FormEvent)=>{
         e.preventDefault();
 
+        if (!validateFormData()) {
+            console.log(error)
+            toast.warning(error)
+            return
+        }
         try{
             const {data:{user}, error: authError } = await supabase.auth.getUser();
             if(!user||authError ){

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -202,6 +202,9 @@ export default function TransactionSubmitForm({
 
     const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
+            if (e.nativeEvent.isComposing) {
+                return;
+            }   
             e.preventDefault()
             addTag()
         }

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -148,7 +148,7 @@ export default function TransactionSubmitForm({
 
             toast("가계부 작성을 완료했습니다")
 
-             setFormData({
+            setFormData({
                 title: "",
                 transactionType: "",
                 amount: "",
@@ -190,8 +190,14 @@ export default function TransactionSubmitForm({
     }
     return (
         <form onSubmit={handleSubmit} className="space-y-6 max-w-md mx-auto p-6">
-            <Label htmlFor="transaction-type" className="text-xl">가계부 작성</Label>
-
+            <div className="flex justify-between items-center sticky top-0 bg-white pb-4 border-b">
+                <Label className="text-xl">
+                    {mode === 'create' ? '가계부 작성' : '가계부 수정'}
+                </Label>
+                <Button type="button" variant="ghost" onClick={onClose}>
+                    <X />
+                </Button>
+            </div>
             <div className="space-y-2">
                 <Label>타이틀</Label>
                 <Input

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -8,7 +8,7 @@ import { Button } from "../ui/button"
 import { supabase } from "@/utils/supabase/client"
 import { toast } from "sonner"
 import { Trash } from "lucide-react"
-CalendarIcon
+import { CATEGORIES } from "@/constants/categories"
 import {
   Popover,
   PopoverContent,
@@ -38,21 +38,9 @@ interface TransactionsSubmitFormProps {
     onClose : ()=> void
     onSuccess : ()=> void
 }
-const CATEGORIES = [
-    { id: "3de48bfe-69d9-4dbb-9a5d-ecdb807212f2", name: "식비", type: "expense" },
-    { id: "fd66cd8e-83bc-4720-8d71-34046524a849", name: "의료비", type: "expense" },
-    { id: "d9f8e176-2594-4a5c-a089-d6cae2fd97ff", name: "쇼핑", type: "expense" },
-    { id: "2f7b8dc5-9c32-4065-ac70-0edc3a02502c", name: "주거비", type: "expense" },
-    { id: "0f93d6d5-5fd0-416a-b9b0-2e42539c0ad9", name: "교통비", type: "expense" },
-    { id: "bee38c89-2393-4f72-8d77-314ca2b9c7e6", name: "문화생활", type: "expense" },
-    { id: "92a9dabd-ca15-420e-be12-2b34ab37dfb3", name: "통신비", type: "expense" },
-    { id: "94b763c9-48cd-4435-b21b-d93a41dd49da", name: "교육비", type: "expense" },
-    { id: "fb48697f-5cae-41e3-869b-0c4922523955", name: "기타", type: "expense" }
-]
 export default function TransactionSubmitForm({
     mode, transaction, onClose, onSuccess
 } : TransactionsSubmitFormProps) {
-
     const [formData, setFormData] = useState({
             title: "",
             transactionType: "",
@@ -287,6 +275,41 @@ export default function TransactionSubmitForm({
                     </button>
                 </div>
             </div>
+            {
+                formData.transactionType !=="" && (
+                    <div className="space-y-2">
+                        <Label>카테고리</Label>
+                        <Popover open={categoryOpen} onOpenChange={setCategoryOpen}>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                >
+                                    {formData.category === "" 
+                                        ? "선택" 
+                                        : (formData.transactionType === "income" 
+                                            ? CATEGORIES.income 
+                                            : CATEGORIES.expense
+                                        ).find(cat => cat.category_key === formData.category)?.name_ko || "선택"
+                                    }
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-auto p-0" align="start">
+                                <div className="grid grid-cols-3">
+                                    {(formData.transactionType==="income" ? CATEGORIES.income : CATEGORIES.expense).map((cat)=>(
+                                        <div
+                                            onClick={()=>{
+                                                setFormData(prev => ({...prev, category: cat.category_key}))
+                                                setCategoryOpen(false)}}
+                                            className="flex items-center justify-center text-center w-24 h-16 cursor-pointer text-sm hover:bg-gray-100" key={cat.category_key}>{cat.name_ko}</div>
+                                    ))}
+                                </div>
+                            </PopoverContent>
+                        </Popover>
+                    </div>
+                )
+            }
+
 
             {/* 금액 입력 */}
             <div className="space-y-2">
@@ -325,31 +348,7 @@ export default function TransactionSubmitForm({
                 </Popover>
             </div>
 
-            <div className="space-y-2">
-                <Label>카테고리</Label>
-                <Popover open={categoryOpen} onOpenChange={setCategoryOpen}>
-                    <PopoverTrigger asChild>
-                        <Button
-                            type="button"
-                            variant="outline"
-                        >
-                            선택
-                        </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                        <div className="grid grid-cols-3">
-                            {CATEGORIES.map((cat)=>(
-                                <div
-                                    onClick={()=>{
-                                        setFormData(prev => ({...prev, category: cat.id}))
-                                        setCategoryOpen(false)}}
-                                    className="text-center w-16 h-16 cursor-pointer" key={cat.id}>{cat.name}</div>
-                            ))}
-                        </div>
-                    </PopoverContent>
-                </Popover>
-                <div>{formData.category}</div>
-
+            
                 {/* 태그 */}
                 <div className="space-y-2">
                 <Label>태그 (선택사항)</Label>
@@ -409,7 +408,6 @@ export default function TransactionSubmitForm({
                 >
                     {mode === 'create' ? '저장' : '수정'}
                 </Button>
-            </div>
             </div>
         </form>
     )

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -35,6 +35,7 @@ export default function TransactionSubmitForm() {
     const [categoryOpen, setCategoryOpen] = useState(false)
     const [tagInput, setTagInput] = useState<string>("")
     const [tags, setTags] = useState<string[]>([])
+    const [error, setError]= useState<string | null>();
 
     const formatDate = (date: Date) => {
         const year = date.getFullYear()
@@ -43,6 +44,34 @@ export default function TransactionSubmitForm() {
         return `${year}년 ${month}월 ${day}일`
     }
 
+    const validateFormData =()=>{
+        setError(null);
+
+        if(!title.trim()){
+            setError("제목을 입력해주세요");
+            return false;
+        }else if(title.trim().length>20){
+            setError("제목은 20자 이내로  입력해주세요")
+            return false;
+        }
+
+        if(!transactionType){
+            setError("거래 유형을 선택해주세요");
+            return false;
+        }
+
+        if(!category){
+            setError("카테고리를 선택해주세요");
+            return false;
+        }
+
+        if(!amount || Number(amount)<=0){
+            setError("금액은 0보다 커야 합니다")
+            return false;
+        }
+        return true;
+
+    }
     const handleSubmit = async(e: React.FormEvent)=>{
         e.preventDefault();
 

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -188,6 +188,31 @@ export default function TransactionSubmitForm({
         }
     }
 
+    const handleDelete = async () => {
+        if(!transaction) return;
+
+        if (!confirm("삭제하시겠습니까?")) return
+
+        try {
+            const { error } = await supabase
+                .from('transactions')
+                .delete()
+                .eq('id', transaction.id)
+
+            if (error) {
+                console.log(error)
+                toast.warning("삭제에 실패했습니다")
+                return
+            }
+
+            toast.success("기록이 삭제되었습니다")
+            onSuccess()
+            onClose()
+        } catch (error) {
+            console.error(error)
+            toast.error("오류가 발생했습니다")
+        }
+    }
     const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             e.preventDefault()
@@ -372,7 +397,7 @@ export default function TransactionSubmitForm({
                     <Button
                         type="button"
                         variant="outline"
-                        onClick={()=>{}}
+                        onClick={()=>handleDelete()}
                         className="w-10"
                     >
                         <Trash/>

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -184,7 +184,7 @@ export default function TransactionSubmitForm({
             onSuccess()
             onClose()
         }catch(error){
-            console.log('error')
+            toast.warning("수정 실패")
         }
     }
 
@@ -200,7 +200,6 @@ export default function TransactionSubmitForm({
                 .eq('id', transaction.id)
 
             if (error) {
-                console.log(error)
                 toast.warning("삭제에 실패했습니다")
                 return
             }
@@ -209,10 +208,10 @@ export default function TransactionSubmitForm({
             onSuccess()
             onClose()
         } catch (error) {
-            console.error(error)
             toast.error("오류가 발생했습니다")
         }
     }
+
     const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             e.preventDefault()
@@ -406,6 +405,7 @@ export default function TransactionSubmitForm({
                 <Button
                     type="submit"
                     className="flex-1"
+                    onClick={(e)=>handleSubmit(e)}
                 >
                     {mode === 'create' ? '저장' : '수정'}
                 </Button>

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -7,6 +7,7 @@ import { Calendar } from "@/components/ui/calendar"
 import { Button } from "../ui/button"
 import { supabase } from "@/utils/supabase/client"
 import { toast } from "sonner"
+import { Trash } from "lucide-react"
 CalendarIcon
 import {
   Popover,
@@ -34,8 +35,8 @@ interface Transaction {
 interface TransactionsSubmitFormProps {
     mode : 'create' | 'edit'
     transaction? : Transaction
-    onClose : ()=> void
-    onSuccess : ()=> void
+    onClose? : ()=> void
+    onSuccess? : ()=> void
 }
 const CATEGORIES = [
     { id: "3de48bfe-69d9-4dbb-9a5d-ecdb807212f2", name: "식비", type: "expense" },
@@ -51,18 +52,34 @@ const CATEGORIES = [
 export default function TransactionSubmitForm({
     mode, transaction, onClose, onSuccess
 } : TransactionsSubmitFormProps) {
-    const [formData, setFormData] = useState({
-        title: "",
-        transactionType: "",
-        amount: "",
-        date: new Date(),
-        category: "",
-        tags: [] as string[]
-    })
+
+    const getInitialFormData = () => {
+        if (mode === 'edit' && transaction) {
+            return {
+                title: transaction.title,
+                transactionType: transaction.type,
+                amount: transaction.amount.toString(),
+                date: new Date(transaction.date),
+                category: transaction.category_id,
+                tags: transaction.tags || []
+            }
+        }
+        return {
+            title: "",
+            transactionType: "",
+            amount: "",
+            date: new Date(),
+            category: "",
+            tags: [] as string[]
+        }
+    }
+    const [formData, setFormData] = useState(getInitialFormData())
+
     const [categoryOpen, setCategoryOpen] = useState(false)
     const [tagInput, setTagInput] = useState<string>("")
     const [error, setError]= useState<string | null>();
 
+    
     const formatDate = (date: Date) => {
         const year = date.getFullYear()
         const month = date.getMonth() + 1
@@ -320,10 +337,24 @@ export default function TransactionSubmitForm({
                     </div>
                 )}
             </div>
-
-            <Button type="submit" className="w-full">
-                제출
-            </Button>
+            <div className="flex gap-2 pt-4 sticky bottom-0 bg-background border-t pb-4">
+                {mode === 'edit' && (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={()=>{}}
+                        className="w-10"
+                    >
+                        <Trash/>
+                    </Button>
+                )}
+                <Button
+                    type="submit"
+                    className="flex-1"
+                >
+                    {mode === 'create' ? '저장' : '수정'}
+                </Button>
+            </div>
             </div>
         </form>
     )

--- a/fe/src/components/ui/sonner.tsx
+++ b/fe/src/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/fe/src/constants/categories.js
+++ b/fe/src/constants/categories.js
@@ -1,0 +1,141 @@
+export const CATEGORIES = {
+  "income": [
+    {
+      "category_key": "SALARY",
+      "name_en": "Salary",
+      "name_ko": "급여"
+    },
+    {
+      "category_key": "BONUS",
+      "name_en": "Bonus",
+      "name_ko": "상여금"
+    },
+    {
+      "category_key": "ALLOWANCE",
+      "name_en": "Allowance",
+      "name_ko": "용돈"
+    },
+    {
+      "category_key": "SIDE_JOB",
+      "name_en": "Side Job",
+      "name_ko": "부업"
+    },
+    {
+      "category_key": "PART_TIME",
+      "name_en": "Part-time",
+      "name_ko": "아르바이트"
+    },
+    {
+      "category_key": "BUSINESS_INCOME",
+      "name_en": "Business Income",
+      "name_ko": "사업수익"
+    },
+    {
+      "category_key": "INVESTMENT_INCOME",
+      "name_en": "Investment Income",
+      "name_ko": "금융수익"
+    },
+    {
+      "category_key": "INSURANCE",
+      "name_en": "Insurance",
+      "name_ko": "보험금"
+    },
+    {
+      "category_key": "SCHOLARSHIP",
+      "name_en": "Scholarship",
+      "name_ko": "장학금"
+    },
+    {
+      "category_key": "REAL_ESTATE",
+      "name_en": "Real Estate",
+      "name_ko": "부동산"
+    },
+    {
+      "category_key": "RESALE",
+      "name_en": "Resale",
+      "name_ko": "중고거래"
+    },
+    {
+      "category_key": "DUTCH_PAY",
+      "name_en": "Dutch Pay",
+      "name_ko": "더치페이"
+    },
+    {
+      "category_key": "OTHER_INCOME",
+      "name_en": "Other Income",
+      "name_ko": "기타"
+    }
+  ],
+  "expense": [
+    {
+      "category_key": "FOOD",
+      "name_en": "Food",
+      "name_ko": "식비"
+    },
+    {
+      "category_key": "TRANSPORT",
+      "name_en": "Transport",
+      "name_ko": "교통"
+    },
+    {
+      "category_key": "CULTURE",
+      "name_en": "Culture/Leisure",
+      "name_ko": "문화/여가"
+    },
+    {
+      "category_key": "SHOPPING",
+      "name_en": "Shopping",
+      "name_ko": "쇼핑"
+    },
+    {
+      "category_key": "BEAUTY",
+      "name_en": "Beauty",
+      "name_ko": "미용"
+    },
+    {
+      "category_key": "MEDICAL",
+      "name_en": "Medical",
+      "name_ko": "의료"
+    },
+    {
+      "category_key": "EVENT",
+      "name_en": "Event",
+      "name_ko": "경조"
+    },
+    {
+      "category_key": "EDUCATION",
+      "name_en": "Education",
+      "name_ko": "교육"
+    },
+    {
+      "category_key": "CHILDCARE",
+      "name_en": "Childcare",
+      "name_ko": "육아"
+    },
+    {
+      "category_key": "HOUSING",
+      "name_en": "Housing",
+      "name_ko": "주거"
+    },
+    {
+      "category_key": "SUBSCRIPTION",
+      "name_en": "Telecom/Subscription",
+      "name_ko": "통신/구독"
+    },
+    {
+      "category_key": "PET",
+      "name_en": "Pet",
+      "name_ko": "반려동물"
+    },
+    {
+      "category_key": "FINANCE",
+      "name_en": "Finance",
+      "name_ko": "금융"
+    },
+    {
+      "category_key": "OTHER_EXPENSE",
+      "name_en": "Other Expense",
+      "name_ko": "기타"
+    }
+  ]
+}

--- a/fe/yarn.lock
+++ b/fe/yarn.lock
@@ -3729,6 +3729,11 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"


### PR DESCRIPTION
## PR 개요

가계부 transaction에 대한 crud 구현 완료 했습니다

## 변경 사항
### 주기능
- 사용자가 기록한 가계부가 리스트 형태로 출력됩니다
- 플로팅 버튼을 통해 내역 생성이 가능합니다
- 리스트 요소의 오른쪽 꺾쇠 버튼을 클릭하면 가계부 상세 정보 열람이 가능합니다
- 상세정보 열람 시 정보를 변경 후 저장하게 되면 수정이 가능합니다
- 상세정보 열람 시 해당 내역을 삭제 가능합니다

### 부기능
- 생성/삭제/수정 완료 혹은 실패 시 toast message가 출력됩니다

### 기타
- 카테고리 constant directory에서 별도로 관리하게 했습니다
- 수입/지출 선택 시 카테고리 선택 UI가 보이도록 했습니다

## 스크린샷
<img width="1044" height="738" alt="#1_transaction_Create" src="https://github.com/user-attachments/assets/77b51130-138b-4543-923e-60c859c8f81a" />
<img width="1045" height="709" alt="#1_transaction_edit" src="https://github.com/user-attachments/assets/d63a8e32-362d-47d8-b3c1-0790cc00b540" />


## 리뷰 요청 사항
- 가계부  CRUD가 전체적으로 정상 동작하는지 확인 부탁드립니다

## 추후 할 일

- [ ] confirm 대체 UI 적용
- [ ] 공통 패널 UI 적용 
- [ ] 가계부 필터링
- [ ] 배포 디버깅
