### PR TITLE
[feat] OAuth 프로필 이미지 연동

### DIFF
--- a/fe/src/app/api/onboarding/profile/route.ts
+++ b/fe/src/app/api/onboarding/profile/route.ts
@@ -48,6 +48,17 @@ export async function POST(req: Request) {
     );
   }
 
+  const { data: existing } = await supabase
+    .from('profiles')
+    .select('profile_image_url')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const profile_image_url =
+    existing?.profile_image_url ??
+    (user.user_metadata?.avatar_url as string | undefined) ??
+    null;
+
   // profiles 저장
   const { error } = await supabase.from('profiles').upsert(
     {
@@ -55,6 +66,7 @@ export async function POST(req: Request) {
       nickname,
       gender,
       birth_date,
+      profile_image_url,
       updated_at: new Date().toISOString(),
     },
     { onConflict: 'id' }

--- a/fe/src/app/api/profile/route.ts
+++ b/fe/src/app/api/profile/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
   const { data, error: selectError } = await supabase
     .from('profiles')
-    .select('nickname, birth_date, gender')
+    .select('nickname, birth_date, gender, profile_image_url')
     .eq('id', user.id)
     .single();
 

--- a/fe/src/components/common/ProfilePanelTrigger.tsx
+++ b/fe/src/components/common/ProfilePanelTrigger.tsx
@@ -4,15 +4,33 @@ import MyInfo from '@/components/my-info/MyInfo';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import ResponsivePanel from '../panel/ResponsivePanel';
+import { useQuery } from '@tanstack/react-query';
+import { Profile } from '@/schemas/profile';
+
+async function fetchProfile(): Promise<Profile> {
+  const res = await fetch('/api/profile', { method: 'GET' });
+  if (!res.ok) throw new Error('프로필 조회 실패');
+  return res.json();
+}
 
 export default function ProfilePanelTrigger() {
+  const { data: profile } = useQuery({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+    retry: false,
+  });
   return (
     <ResponsivePanel
       trigger={
         <Button variant="ghost" size="icon" className="rounded-full">
-          <Avatar className="h-10 w-10">
-            <AvatarImage src="" alt="프로필" />
-            <AvatarFallback>ME</AvatarFallback>
+          <Avatar className="h-8 w-8">
+            <AvatarImage
+              src={profile?.profile_image_url ?? undefined}
+              alt="프로필"
+            />
+            <AvatarFallback>
+              {profile?.nickname?.[0]?.toUpperCase() ?? 'ME'}
+            </AvatarFallback>
           </Avatar>
         </Button>
       }

--- a/fe/src/components/my-info/MyInfo.tsx
+++ b/fe/src/components/my-info/MyInfo.tsx
@@ -3,14 +3,14 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ProfileFormValues } from '@/schemas/profile';
+import { Profile, ProfileFormValues } from '@/schemas/profile';
 import { Separator } from '@/components/ui/separator';
 import LogoutButton from './LogoutButton';
 import ProfileEdit from './ProfileEdit';
 import ProfileView from './ProfileView';
 
 // 프로필 조회 함수
-async function fetchProfile(): Promise<ProfileFormValues> {
+async function fetchProfile(): Promise<Profile> {
   const res = await fetch('/api/profile', { method: 'GET' });
   if (!res.ok) throw new Error('프로필 조회 실패');
   return res.json();

--- a/fe/src/components/my-info/ProfileView.tsx
+++ b/fe/src/components/my-info/ProfileView.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { ProfileFormValues } from '@/schemas/profile';
+import { Profile } from '@/schemas/profile';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 type ProfileViewProps = {
-  profile: ProfileFormValues;
+  profile: Profile;
   onEdit: () => void;
 };
 
-const genderLabel = (gender: ProfileFormValues['gender']) => {
+const genderLabel = (gender: Profile['gender']) => {
   return gender === 'male' ? '남' : '여';
 };
 
@@ -19,8 +19,13 @@ export default function ProfileView({ profile, onEdit }: ProfileViewProps) {
       {/* 왼쪽: 프로필 이미지 */}
       <div className="shrink-0">
         <Avatar className="h-16 w-16">
-          <AvatarImage src="" alt="프로필 이미지" />
-          <AvatarFallback>ME</AvatarFallback>
+          <AvatarImage
+            src={profile.profile_image_url ?? undefined}
+            alt="프로필 이미지"
+          />
+          <AvatarFallback>
+            {profile.nickname?.[0]?.toUpperCase() ?? 'ME'}
+          </AvatarFallback>
         </Avatar>
       </div>
 

--- a/fe/src/schemas/profile.ts
+++ b/fe/src/schemas/profile.ts
@@ -11,3 +11,7 @@ export const profileSchema = z.object({
 });
 
 export type ProfileFormValues = z.infer<typeof profileSchema>;
+
+export type Profile = ProfileFormValues & {
+  profile_image_url: string | null;
+};


### PR DESCRIPTION
## PR 개요

OAuth 로그인(Google/Kakao) 시 제공되는 기본 프로필 이미지를  `profiles.profile_image_url`로 저장하고,
MyInfo 패널과 헤더 프로필 트리거에서 해당 이미지를 표시하도록 구현했습니다.

## 변경 사항

- OAuth 로그인 시 제공되는 `avatar_url`을 온보딩 프로필 생성 시 저장
- `/api/profile` 조회 API에 `profile_image_url` 필드 포함
- MyInfo 프로필 화면에서 프로필 이미지(Avatar) 표시
- 헤더 프로필 버튼(ProfilePanelTrigger)에 사용자 프로필 이미지 연동

## 스크린샷

<img width="526" height="186" alt="image" src="https://github.com/user-attachments/assets/86707f10-c03b-49b9-959b-ecf9047fefad" />

## 리뷰 요청 사항

- 본인 로그인 계정의 프로필 사진이 헤더 및 MyInfo 화면에 정상적으로 표시되는지 확인 부탁드립니다.

## 추후 할 일

- [ ] MyInfo 리팩토링 #22 