### PR TITLE
[feat] 고정비 수정 기능 구현

### DIFF
--- a/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+type FixedCostEditConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApplyThisMonth: () => void;
+  onApplyFuture: () => void;
+};
+
+export default function FixedCostEditConfirmDialog({
+  open,
+  onOpenChange,
+  onApplyThisMonth,
+  onApplyFuture,
+}: FixedCostEditConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>고정비 수정 적용 범위</DialogTitle>
+          <DialogDescription>
+            수정한 내용을 어디까지 적용할지 선택해주세요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-4 flex flex-col gap-2">
+          <Button variant="outline" onClick={onApplyThisMonth}>
+            이번 달만 적용
+          </Button>
+          <Button variant="outline" onClick={onApplyFuture}>
+            이후 전부 적용
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner';
 import FixedCostScheduleFields from './FixedCostsScheduleFields';
 import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatLocalDate } from '@/utils/date';
-import { createFixedRule } from '@/services/fixed-costs';
+import { createFixedRule, updateFixedRule } from '@/services/fixed-costs';
 import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
 
@@ -78,6 +78,22 @@ export default function FixedCostSubmitForm({
     }
   };
 
+  const handleApplyFuture = async () => {
+    if (!ruleId || !pendingPayload) return;
+
+    try {
+      await updateFixedRule(ruleId, pendingPayload);
+      toast.success('고정비가 수정되었습니다.');
+
+      setConfirmOpen(false);
+      setPendingPayload(null);
+
+      onSuccess();
+    } catch {
+      toast.error('고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    }
+  };
+
   return (
     <div className="flex h-full flex-col px-6">
       <form onSubmit={handleSubmit} className="flex h-full flex-col space-y-6">
@@ -132,9 +148,7 @@ export default function FixedCostSubmitForm({
         onApplyThisMonth={() => {
           toast('이번 달만 적용');
         }}
-        onApplyFuture={() => {
-          toast('다음 달부터 적용');
-        }}
+        onApplyFuture={handleApplyFuture}
       />
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -13,13 +13,13 @@ import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatDateYYYYMMDD } from '@/utils/date';
 import { createFixedRule } from '@/services/fixed-costs';
 
-type FixedCostCreateFormProps = {
+type FixedCostSubmitFormProps = {
   onSuccess: () => void;
 };
 
-export default function FixedCostCreateForm({
+export default function FixedCostSubmitForm({
   onSuccess,
-}: FixedCostCreateFormProps) {
+}: FixedCostSubmitFormProps) {
   const {
     formData,
     categoryOpen,

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -16,12 +16,14 @@ import { createFixedRule } from '@/services/fixed-costs';
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
   initialData?: Partial<IFixedCostFormData>;
+  ruleId?: string;
   onSuccess: () => void;
 };
 
 export default function FixedCostSubmitForm({
   mode,
   initialData,
+  ruleId,
   onSuccess,
 }: FixedCostSubmitFormProps) {
   const {

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -6,7 +6,7 @@ import { TitleInput } from '../transaction/common/TitleInput';
 import { TypeSelector } from '../transaction/common/TypeSelector';
 import { CategorySelector } from '../transaction/common/CategorySelector';
 import { AmountInput } from '../transaction/common/AmountInput';
-import { useFixedCostForm } from '@/hooks/useFixedCostForm';
+import { IFixedCostFormData, useFixedCostForm } from '@/hooks/useFixedCostForm';
 import { toast } from 'sonner';
 import FixedCostScheduleFields from './FixedCostsScheduleFields';
 import { CreateFixedRuleInput } from '@/types/fixed-costs';
@@ -14,10 +14,14 @@ import { formatDateYYYYMMDD } from '@/utils/date';
 import { createFixedRule } from '@/services/fixed-costs';
 
 type FixedCostSubmitFormProps = {
+  mode: 'create' | 'edit';
+  initialData?: Partial<IFixedCostFormData>;
   onSuccess: () => void;
 };
 
 export default function FixedCostSubmitForm({
+  mode,
+  initialData,
   onSuccess,
 }: FixedCostSubmitFormProps) {
   const {
@@ -26,7 +30,7 @@ export default function FixedCostSubmitForm({
     setCategoryOpen,
     UpdateField,
     validateFormData,
-  } = useFixedCostForm();
+  } = useFixedCostForm(initialData);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,11 +58,19 @@ export default function FixedCostSubmitForm({
     };
 
     try {
-      await createFixedRule(payload);
-      toast.success('고정비가 추가되었습니다.');
+      if (mode === 'create') {
+        await createFixedRule(payload);
+        toast.success('고정비가 추가되었습니다.');
+      } else {
+        toast.success('고정비가 수정되었습니다.');
+      }
       onSuccess(); // 고정비 목록 갱신
     } catch {
-      toast.error('고정비 추가에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      toast.error(
+        mode === 'create'
+          ? '고정비 추가에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+          : '고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+      );
     }
   };
 
@@ -66,7 +78,9 @@ export default function FixedCostSubmitForm({
     <div className="flex h-full flex-col px-6">
       <form onSubmit={handleSubmit} className="flex h-full flex-col space-y-6">
         <div className="border-b pb-4">
-          <Label className="text-xl">고정비 추가</Label>
+          <Label className="text-xl">
+            {mode === 'create' ? '고정비 추가' : '고정비 수정'}
+          </Label>
         </div>
 
         <TitleInput
@@ -103,7 +117,7 @@ export default function FixedCostSubmitForm({
 
         <div className="mt-auto border-t pt-4 pb-4">
           <Button type="submit" className="w-full">
-            저장
+            {mode === 'create' ? '저장' : '수정'}
           </Button>
         </div>
       </form>

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -13,6 +13,7 @@ import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatLocalDate } from '@/utils/date';
 import { createFixedRule } from '@/services/fixed-costs';
 import { useState } from 'react';
+import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
 
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
@@ -124,6 +125,17 @@ export default function FixedCostSubmitForm({
           </Button>
         </div>
       </form>
+
+      <FixedCostEditConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onApplyThisMonth={() => {
+          toast('이번 달만 적용');
+        }}
+        onApplyFuture={() => {
+          toast('다음 달부터 적용');
+        }}
+      />
     </div>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -11,7 +11,11 @@ import { toast } from 'sonner';
 import FixedCostScheduleFields from './FixedCostsScheduleFields';
 import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatLocalDate } from '@/utils/date';
-import { createFixedRule, updateFixedRule } from '@/services/fixed-costs';
+import {
+  createFixedRule,
+  updateFixedRule,
+  updateFixedRuleThisMonth,
+} from '@/services/fixed-costs';
 import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
 
@@ -94,6 +98,34 @@ export default function FixedCostSubmitForm({
     }
   };
 
+  const handleApplyThisMonth = async () => {
+    if (!ruleId || !pendingPayload) return;
+
+    try {
+      const updated = await updateFixedRuleThisMonth(ruleId, {
+        title: pendingPayload.title,
+        type: pendingPayload.type,
+        amount: pendingPayload.amount,
+        category_id: pendingPayload.category_id,
+      });
+
+      if (updated.length === 0) {
+        toast('이번 달에 생성된 고정비 거래가 없습니다.');
+      } else {
+        toast.success('이번 달 고정비 거래가 수정되었습니다.');
+      }
+
+      setConfirmOpen(false);
+      setPendingPayload(null);
+
+      onSuccess();
+    } catch {
+      toast.error(
+        '이번 달 고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+      );
+    }
+  };
+
   return (
     <div className="flex h-full flex-col px-6">
       <form onSubmit={handleSubmit} className="flex h-full flex-col space-y-6">
@@ -145,9 +177,7 @@ export default function FixedCostSubmitForm({
       <FixedCostEditConfirmDialog
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
-        onApplyThisMonth={() => {
-          toast('이번 달만 적용');
-        }}
+        onApplyThisMonth={handleApplyThisMonth}
         onApplyFuture={handleApplyFuture}
       />
     </div>

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -12,6 +12,7 @@ import FixedCostScheduleFields from './FixedCostsScheduleFields';
 import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatLocalDate } from '@/utils/date';
 import { createFixedRule } from '@/services/fixed-costs';
+import { useState } from 'react';
 
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
@@ -26,6 +27,10 @@ export default function FixedCostSubmitForm({
   ruleId,
   onSuccess,
 }: FixedCostSubmitFormProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingPayload, setPendingPayload] =
+    useState<CreateFixedRuleInput | null>(null);
+
   const {
     formData,
     categoryOpen,
@@ -57,20 +62,18 @@ export default function FixedCostSubmitForm({
       end_date: formData.end_date ? formatLocalDate(formData.end_date) : null,
     };
 
+    if (mode === 'edit') {
+      setPendingPayload(payload);
+      setConfirmOpen(true);
+      return;
+    }
+
     try {
-      if (mode === 'create') {
-        await createFixedRule(payload);
-        toast.success('고정비가 추가되었습니다.');
-      } else {
-        toast.success('고정비가 수정되었습니다.');
-      }
+      await createFixedRule(payload);
+      toast.success('고정비가 추가되었습니다.');
       onSuccess(); // 고정비 목록 갱신
     } catch {
-      toast.error(
-        mode === 'create'
-          ? '고정비 추가에 실패했습니다. 잠시 후 다시 시도해 주세요.'
-          : '고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.'
-      );
+      toast.error('고정비 추가에 실패했습니다. 잠시 후 다시 시도해 주세요.');
     }
   };
 

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -10,7 +10,7 @@ import { IFixedCostFormData, useFixedCostForm } from '@/hooks/useFixedCostForm';
 import { toast } from 'sonner';
 import FixedCostScheduleFields from './FixedCostsScheduleFields';
 import { CreateFixedRuleInput } from '@/types/fixed-costs';
-import { formatDateYYYYMMDD } from '@/utils/date';
+import { formatLocalDate } from '@/utils/date';
 import { createFixedRule } from '@/services/fixed-costs';
 
 type FixedCostSubmitFormProps = {
@@ -51,10 +51,8 @@ export default function FixedCostSubmitForm({
       weekday: formData.weekday,
       monthday: formData.monthday,
 
-      start_date: formatDateYYYYMMDD(formData.start_date),
-      end_date: formData.end_date
-        ? formatDateYYYYMMDD(formData.end_date)
-        : null,
+      start_date: formatLocalDate(formData.start_date),
+      end_date: formData.end_date ? formatLocalDate(formData.end_date) : null,
     };
 
     try {

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -16,6 +16,7 @@ type FixedCostsListProps = {
   isLoading: boolean;
   emptyMessage: string;
   onToggleActive: (id: string, nextActive: boolean) => void;
+  onEdit: (rule: IFixedRule) => void;
 };
 
 export default function FixedCostsList({
@@ -23,6 +24,7 @@ export default function FixedCostsList({
   isLoading,
   emptyMessage,
   onToggleActive,
+  onEdit,
 }: FixedCostsListProps) {
   if (isLoading) {
     return (
@@ -69,7 +71,11 @@ export default function FixedCostsList({
                 checked={e.is_active}
                 onCheckedChange={(v) => onToggleActive(e.id, v)}
               />
-              <Button className="cursor-pointer" size="sm">
+              <Button
+                className="cursor-pointer"
+                size="sm"
+                onClick={() => onEdit(e)}
+              >
                 <ChevronRight />
               </Button>
             </ItemActions>

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -10,6 +10,7 @@ import FixedCostSubmitForm from './FixedCostSubmitForm';
 import { IFixedRule } from '@/types/fixed-costs';
 import { fetchFixedRules, setFixedRuleActive } from '@/services/fixed-costs';
 import { toast } from 'sonner';
+import { mapFixedRuleToFormData } from '@/utils/fixed-costs';
 
 type TabValue = 'all' | 'active' | 'inactive';
 
@@ -18,6 +19,8 @@ export default function FixedCostsPage() {
   const [items, setItems] = useState<IFixedRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [editingRule, setEditingRule] = useState<IFixedRule | null>(null);
 
   const fetchData = async () => {
     try {
@@ -36,6 +39,12 @@ export default function FixedCostsPage() {
   useEffect(() => {
     fetchData();
   }, []);
+
+  const handleCreateClick = () => {
+    setFormMode('create');
+    setEditingRule(null);
+    setIsPanelOpen(true);
+  };
 
   const handleCreateSuccess = async () => {
     await fetchData();
@@ -77,11 +86,23 @@ export default function FixedCostsPage() {
     }
   };
 
+  const handleEditClick = (rule: IFixedRule) => {
+    setFormMode('edit');
+    setEditingRule(rule);
+    setIsPanelOpen(true);
+  };
+
   return (
     <div className="mx-auto min-h-screen w-full max-w-lg space-y-6 p-4 md:p-6 lg:p-8">
-      <FixedCostsAddButton onClick={() => setIsPanelOpen(true)} />
+      <FixedCostsAddButton onClick={handleCreateClick} />
       <ResponsivePanel isOpen={isPanelOpen} setIsOpen={setIsPanelOpen}>
-        <FixedCostSubmitForm onSuccess={handleCreateSuccess} />
+        <FixedCostSubmitForm
+          mode={formMode}
+          initialData={
+            editingRule ? mapFixedRuleToFormData(editingRule) : undefined
+          }
+          onSuccess={handleCreateSuccess}
+        />
       </ResponsivePanel>
 
       <header>
@@ -122,6 +143,7 @@ export default function FixedCostsPage() {
             isLoading={isLoading}
             emptyMessage={emptyMessage}
             onToggleActive={handleToggleActive}
+            onEdit={handleEditClick}
           />
         </TabsContent>
       </Tabs>

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -6,7 +6,7 @@ import FixedCostsList from './FixedCostsList';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import ResponsivePanel from '../panel/ResponsivePanel';
-import FixedCostCreateForm from './FixedCostsCreateForm';
+import FixedCostSubmitForm from './FixedCostSubmitForm';
 import { IFixedRule } from '@/types/fixed-costs';
 import { fetchFixedRules, setFixedRuleActive } from '@/services/fixed-costs';
 import { toast } from 'sonner';
@@ -81,7 +81,7 @@ export default function FixedCostsPage() {
     <div className="mx-auto min-h-screen w-full max-w-lg space-y-6 p-4 md:p-6 lg:p-8">
       <FixedCostsAddButton onClick={() => setIsPanelOpen(true)} />
       <ResponsivePanel isOpen={isPanelOpen} setIsOpen={setIsPanelOpen}>
-        <FixedCostCreateForm onSuccess={handleCreateSuccess} />
+        <FixedCostSubmitForm onSuccess={handleCreateSuccess} />
       </ResponsivePanel>
 
       <header>

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -98,6 +98,7 @@ export default function FixedCostsPage() {
       <ResponsivePanel isOpen={isPanelOpen} setIsOpen={setIsPanelOpen}>
         <FixedCostSubmitForm
           mode={formMode}
+          ruleId={editingRule?.id}
           initialData={
             editingRule ? mapFixedRuleToFormData(editingRule) : undefined
           }

--- a/fe/src/components/ui/dialog.tsx
+++ b/fe/src/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/fe/src/services/fixed-costs.ts
+++ b/fe/src/services/fixed-costs.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/utils/supabase/client';
 import type { CreateFixedRuleInput, IFixedRule } from '@/types/fixed-costs';
+import { getMonthRange } from '@/utils/date';
 
 const requireUserId = async () => {
   const {
@@ -77,4 +78,35 @@ export const updateFixedRule = async (
 
   if (error) throw error;
   return data as IFixedRule;
+};
+
+type UpdateFixedThisMonthInput = Pick<
+  CreateFixedRuleInput,
+  'title' | 'type' | 'amount' | 'category_id'
+>;
+
+// 이번 달에 생성된 고정비 거래만 수정
+export const updateFixedRuleThisMonth = async (
+  fixedRuleId: string,
+  input: UpdateFixedThisMonthInput
+) => {
+  const userId = await requireUserId();
+  const { startDate, endDate } = getMonthRange(new Date());
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .update({
+      title: input.title,
+      type: input.type,
+      amount: input.amount,
+      category_id: input.category_id,
+    })
+    .eq('user_id', userId)
+    .eq('fixed_rule_id', fixedRuleId)
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .select('id');
+
+  if (error) throw error;
+  return data ?? [];
 };

--- a/fe/src/services/fixed-costs.ts
+++ b/fe/src/services/fixed-costs.ts
@@ -59,3 +59,22 @@ export const createFixedRule = async (input: CreateFixedRuleInput) => {
   if (error) throw error;
   return data as IFixedRule;
 };
+
+// 고정비 항목 수정
+export const updateFixedRule = async (
+  id: string,
+  input: CreateFixedRuleInput
+) => {
+  const userId = await requireUserId();
+
+  const { data, error } = await supabase
+    .from('fixed_rules')
+    .update(input)
+    .eq('id', id)
+    .eq('user_id', userId)
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  return data as IFixedRule;
+};

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -8,7 +8,7 @@ export const getMonthRange = (date: Date) => {
 
   // 'YYYY-MM-DD' 형식의 문자열 생성
   const startDate = `${year}-${formatMonth}-01`;
-  const endDate = `${year}-${formatMonth}-${lastDay}`;
+  const endDate = `${year}-${formatMonth}-${String(lastDay).padStart(2, '0')}`;
 
   return { startDate, endDate };
 };

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -13,10 +13,18 @@ export const getMonthRange = (date: Date) => {
   return { startDate, endDate };
 };
 
-// YYYY-MM-DD 형식으로 날짜 변환
-export const formatDateYYYYMMDD = (date: Date) => {
+// Date 객체를 'YYYY-MM-DD' 문자열로 변환
+export const formatLocalDate = (date: Date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+};
+
+// 'YYYY-MM-DD' 문자열을 로컬 Date로 변환 (시간 00:00 고정)
+export const parseLocalDate = (value?: string | null): Date | undefined => {
+  if (!value) return undefined;
+
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, (month ?? 1) - 1, day ?? 1, 0, 0, 0, 0);
 };

--- a/fe/src/utils/fixed-costs.ts
+++ b/fe/src/utils/fixed-costs.ts
@@ -1,5 +1,6 @@
 import { IFixedCostFormData } from '@/hooks/useFixedCostForm';
 import { IFixedRule } from '@/types/fixed-costs';
+import { parseLocalDate } from './date';
 
 const WEEKDAY_LABEL: Record<number, string> = {
   1: '월',
@@ -40,8 +41,8 @@ export const mapFixedRuleToFormData = (
   weekday: rule.weekday ?? null,
   monthday: rule.monthday ?? null,
 
-  start_date: new Date(rule.start_date),
-  end_date: rule.end_date ? new Date(rule.end_date) : null,
+  start_date: parseLocalDate(rule.start_date),
+  end_date: rule.end_date ? parseLocalDate(rule.end_date) : null,
 
   is_active: rule.is_active,
 });

--- a/fe/src/utils/fixed-costs.ts
+++ b/fe/src/utils/fixed-costs.ts
@@ -1,3 +1,6 @@
+import { IFixedCostFormData } from '@/hooks/useFixedCostForm';
+import { IFixedRule } from '@/types/fixed-costs';
+
 const WEEKDAY_LABEL: Record<number, string> = {
   1: '월',
   2: '화',
@@ -23,3 +26,22 @@ export const formatFixedRuleCycle = (rule: {
 
   return '';
 };
+
+// 고정비 테이블 값을 고정비 폼 초기값으로 변환
+export const mapFixedRuleToFormData = (
+  rule: IFixedRule
+): Partial<IFixedCostFormData> => ({
+  title: rule.title ?? '',
+  type: rule.type,
+  amount: String(rule.amount),
+  category_id: rule.category_id,
+
+  cycle: rule.cycle,
+  weekday: rule.weekday ?? null,
+  monthday: rule.monthday ?? null,
+
+  start_date: new Date(rule.start_date),
+  end_date: rule.end_date ? new Date(rule.end_date) : null,
+
+  is_active: rule.is_active,
+});

--- a/fe/yarn.lock
+++ b/fe/yarn.lock
@@ -865,8 +865,6 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
-<<<<<<< HEAD
-=======
 "@radix-ui/react-switch@^1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.2.6.tgz#ff79acb831f0d5ea9216cfcc5b939912571358e3"
@@ -880,7 +878,6 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
->>>>>>> e49888e9b0d62798e4029eab3620cc7be1aa46f9
 "@radix-ui/react-tabs@^1.1.13":
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"


### PR DESCRIPTION
## PR 개요
- 고정비 관리 페이지에서 기존에 등록된 고정비를 수정하는 기능을 구현했습니다.
- 수정 진입부터 적용 범위 선택 (이번 달/이후 전부)에 따른 저장 처리까지 고정비 수정 플로우 전반을 구현했습니다.

>이번 PR에서는
고정비 규칙 수정 시 **이미 생성된 거래가 존재하는 경우를 대비한 수정 로직**까지 구현했으며,
고정비 규칙을 기반으로 거래를 생성하는 Lazy 생성 로직은 아직 연결하지 않은 상태입니다.

## 변경 사항

### 1. 고정비 작성/수정 폼 구조 개선 (create / edit 통합)
- `FixedCostSubmitForm`에 `create / edit` 모드 도입
- `mode`, `initialData`, `ruleId` props 추가
- `useFixedCostForm(initialData)` 연결로 수정 시 기존 값 초기 주입
- 폼 타이틀 및 버튼 텍스트를 모드에 따라 분기 처리
- submit 단계에서 create / edit 흐름 분리
    - create: 즉시 생성 API 호출
    - edit: payload 보관 후 확인 단계로 이동

### 2. 고정비 수정 패널 진입 및 초기값 매핑
- 고정비 목록 아이템의 수정 버튼 클릭 시 수정 패널 오픈
- `FixedCostsPage`에서 edit 상태 및 대상 고정비 관리
- `mapFixedRuleToFormData` 추가
    - amount, date 타입 차이 해결
- 날짜 파싱을 로컬 기준(`YYYY-MM-DD`)으로 처리하도록 기존 유틸 개선
  - `endDate` 생성 시 말일이 한 자리(예: 9)일 경우 `YYYY-MM-9` 형태가 될 수 있어, Supabase date 비교에서 안전한 `YYYY-MM-DD` 포맷을 보장하도록 day에 `padStart(2, '0')` 적용

### 3. 고정비 수정 적용 범위 선택 UI 추가
- 수정 저장 시 적용 범위를 선택하는 확인 모달 추가
    - 이번 달만 적용
    - 이후 전부 적용
    - shadcn/dialog 사용
- 모달 컴포넌트 분리
    - 폼: payload 생성 및 상태 관리
    - Dialog: UI 렌더링 및 선택 결과 전달

### 4. 고정비 수정 정책에 따른 저장 처리
- **이후 전부 적용**
    - `fixed_rules` 업데이트
    - 수정 완료 후 패널 닫기 및 목록 갱신
- **이번 달만 적용**
    - 이번 달에 생성된 `transactions`만 업데이트
    - 수정 대상 거래가 없는 경우(0건) 안내 메시지 처리
- 고정비 수정 관련 서비스 함수 추가
    - `updateFixedRule`
    - `updateFixedRuleThisMonth` 

## 스크린샷
- 고정비 수정 패널
<img width="416" height="793" alt="image" src="https://github.com/user-attachments/assets/e2cb245e-fe64-4ee6-aecd-16e804416387"/>

- 고정비 수정 확인 모달
<img width="416" height="240" alt="image" src="https://github.com/user-attachments/assets/07f8da7d-e73a-4d63-be0d-551e522fe5d4" />


## 리뷰 요청 사항

- 고정비 수정 플로우가 정책에 맞게 동작하는지 확인 부탁드립니다.
  - 수정 패널 진입 시 초기값이 제대로 나타나는지
  - 적용 범위 선택 모달이 수정 완료 전에 나타나는지
  - 수정 완료 시 Supabase 에 업데이트 시간이 제대로 기록되는지

## 추후 할 일

- [x] 월 진입 시 고정비 거래 Lazy 생성 로직 구현 #39 