### PR TITLE
[feat] 고정비 삭제 기능 구현

### DIFF
--- a/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
@@ -58,13 +58,13 @@ export default function FixedCostDeleteDialog({ onDelete }: Props) {
           <li>• 삭제 이후에는 자동 거래 생성이 중단됩니다.</li>
         </ul>
 
-        <DialogFooter className="mt-2 flex">
+        <DialogFooter className="mt-2 flex gap-2">
           <Button
             type="button"
             variant="outline"
             onClick={() => setOpen(false)}
             disabled={pending}
-            className="flex-1/2"
+            className="flex-1"
           >
             취소
           </Button>
@@ -73,7 +73,7 @@ export default function FixedCostDeleteDialog({ onDelete }: Props) {
             variant="destructive"
             onClick={handleConfirmDelete}
             disabled={pending}
-            className="flex-1/2"
+            className="flex-1"
           >
             삭제
           </Button>

--- a/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+type Props = {
+  onDelete: () => void | Promise<void>;
+};
+
+export default function FixedCostDeleteDialog({ onDelete }: Props) {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  const handleConfirmDelete = async () => {
+    try {
+      setPending(true);
+      await onDelete();
+      setOpen(false);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-destructive inline-flex h-10 w-10 items-center justify-center rounded-md border"
+          aria-label="고정비 규칙 삭제"
+        >
+          <Trash className="h-4 w-4" />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>고정비 규칙을 삭제하시겠습니까?</DialogTitle>
+          <DialogDescription>
+            ⚠️ 이 작업은 되돌릴 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="text-muted-foreground mt-2 space-y-1 text-sm">
+          <li>• 해당 고정비 규칙은 완전히 삭제됩니다.</li>
+          <li>• 이 규칙으로 생성된 거래는 삭제되지 않습니다.</li>
+          <li>• 기존 거래는 일반 거래로 유지되며, 고정비 연결만 해제됩니다.</li>
+          <li>• 삭제 이후에는 자동 거래 생성이 중단됩니다.</li>
+        </ul>
+
+        <DialogFooter className="mt-2 flex">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+            className="flex-1/2"
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirmDelete}
+            disabled={pending}
+            className="flex-1/2"
+          >
+            삭제
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -13,6 +13,7 @@ import { CreateFixedRuleInput } from '@/types/fixed-costs';
 import { formatLocalDate } from '@/utils/date';
 import {
   createFixedRule,
+  deleteFixedRule,
   updateFixedRule,
   updateFixedRuleThisMonth,
 } from '@/services/fixed-costs/fixed-costs';
@@ -128,7 +129,17 @@ export default function FixedCostSubmitForm({
   };
 
   const handleDeleteRule = async () => {
-    console.log('delete rule');
+    if (!ruleId) return;
+
+    try {
+      await deleteFixedRule(ruleId);
+      toast.success('고정비 규칙이 삭제되었습니다.');
+      onSuccess();
+    } catch {
+      toast.error(
+        '고정비 규칙 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+      );
+    }
   };
 
   return (
@@ -179,7 +190,7 @@ export default function FixedCostSubmitForm({
             </Button>
           ) : (
             <div className="flex items-center gap-2">
-              <FixedCostDeleteDialog onDelete={handleDeleteRule} />
+              {ruleId && <FixedCostDeleteDialog onDelete={handleDeleteRule} />}
               <Button type="submit" className="flex-1">
                 수정
               </Button>

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/services/fixed-costs/fixed-costs';
 import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
+import FixedCostDeleteDialog from './FixedCostDeleteDialog';
 
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
@@ -126,6 +127,10 @@ export default function FixedCostSubmitForm({
     }
   };
 
+  const handleDeleteRule = async () => {
+    console.log('delete rule');
+  };
+
   return (
     <div className="flex h-full flex-col px-6">
       <form onSubmit={handleSubmit} className="flex h-full flex-col space-y-6">
@@ -168,9 +173,18 @@ export default function FixedCostSubmitForm({
         />
 
         <div className="mt-auto border-t pt-4 pb-4">
-          <Button type="submit" className="w-full">
-            {mode === 'create' ? '저장' : '수정'}
-          </Button>
+          {mode === 'create' ? (
+            <Button type="submit" className="w-full">
+              저장
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <FixedCostDeleteDialog onDelete={handleDeleteRule} />
+              <Button type="submit" className="flex-1">
+                수정
+              </Button>
+            </div>
+          )}
         </div>
       </form>
 

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -5,25 +5,21 @@ import {
   ItemTitle,
 } from '@/components/ui/item';
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { ChevronRight } from 'lucide-react';
 import { IFixedRule } from '@/types/fixed-costs';
 import { formatFixedRuleCycle } from '@/utils/fixed-costs';
+import { THEME_COLOR } from '@/constants/colors';
 
 type FixedCostsListProps = {
   items: IFixedRule[];
   isLoading: boolean;
-  emptyMessage: string;
-  onToggleActive: (id: string, nextActive: boolean) => void;
   onEdit: (rule: IFixedRule) => void;
 };
 
 export default function FixedCostsList({
   items,
   isLoading,
-  emptyMessage,
-  onToggleActive,
   onEdit,
 }: FixedCostsListProps) {
   if (isLoading) {
@@ -37,7 +33,10 @@ export default function FixedCostsList({
   if (items.length === 0) {
     return (
       <div className="text-muted-foreground rounded-md border p-6 text-center text-sm whitespace-pre-line">
-        {emptyMessage}
+        <p>
+          등록된 고정비가 없습니다. <br /> 상단의 + 버튼을 눌러 고정비를 추가해
+          주세요.
+        </p>
       </div>
     );
   }
@@ -45,11 +44,7 @@ export default function FixedCostsList({
   return (
     <div className="space-y-2">
       {items.map((e) => (
-        <Item
-          variant="outline"
-          key={e.id}
-          className={cn(!e.is_active && 'opacity-50')}
-        >
+        <Item variant="outline" key={e.id}>
           <ItemContent className="flex flex-row items-center">
             <div className="flex w-24 flex-col gap-1">
               <span className="text-muted-foreground text-xs">
@@ -58,7 +53,7 @@ export default function FixedCostsList({
               <span
                 className={cn(
                   'text-sm font-bold',
-                  e.type === 'income' ? 'text-blue-400' : 'text-red-400'
+                  e.type === 'income' ? THEME_COLOR.INCOME : THEME_COLOR.EXPENSE
                 )}
               >
                 {e.type === 'income' ? '+' : '-'}
@@ -67,10 +62,6 @@ export default function FixedCostsList({
             </div>
             <ItemTitle className="p-2 text-left">{e.title}</ItemTitle>
             <ItemActions className="ml-auto">
-              <Switch
-                checked={e.is_active}
-                onCheckedChange={(v) => onToggleActive(e.id, v)}
-              />
               <Button
                 className="cursor-pointer"
                 size="sm"

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useState } from 'react';
 import FixedCostsAddButton from './FixedCostsAddButton';
 import FixedCostsList from './FixedCostsList';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Badge } from '@/components/ui/badge';
 import ResponsivePanel from '../panel/ResponsivePanel';
 import FixedCostSubmitForm from './FixedCostSubmitForm';
 import { IFixedRule } from '@/types/fixed-costs';
@@ -15,10 +13,7 @@ import {
 import { toast } from 'sonner';
 import { mapFixedRuleToFormData } from '@/utils/fixed-costs';
 
-type TabValue = 'all' | 'active' | 'inactive';
-
 export default function FixedCostsPage() {
-  const [tab, setTab] = useState<TabValue>('all');
   const [items, setItems] = useState<IFixedRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
@@ -54,41 +49,6 @@ export default function FixedCostsPage() {
     setIsPanelOpen(false);
   };
 
-  const filteredItems =
-    tab === 'active'
-      ? items.filter((i) => i.is_active)
-      : tab === 'inactive'
-        ? items.filter((i) => !i.is_active)
-        : items;
-
-  const counts = {
-    all: items.length,
-    active: items.filter((i) => i.is_active).length,
-    inactive: items.filter((i) => !i.is_active).length,
-  };
-
-  const emptyMessage =
-    tab === 'all'
-      ? '등록된 고정비가 없습니다. \n\n상단의 + 버튼을 눌러 고정비를 추가해 주세요.'
-      : tab === 'active'
-        ? '활성화된 고정비가 없습니다.'
-        : '비활성화된 고정비가 없습니다.';
-
-  const handleToggleActive = async (id: string, nextActive: boolean) => {
-    try {
-      await setFixedRuleActive(id, nextActive);
-      setItems((prev) =>
-        prev.map((item) =>
-          item.id === id ? { ...item, is_active: nextActive } : item
-        )
-      );
-    } catch {
-      toast.error(
-        '고정비 활성화 상태 변경 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.'
-      );
-    }
-  };
-
   const handleEditClick = (rule: IFixedRule) => {
     setFormMode('edit');
     setEditingRule(rule);
@@ -113,44 +73,11 @@ export default function FixedCostsPage() {
         <h1 className="text-xl font-semibold">고정비 관리</h1>
       </header>
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="all">
-            <span className="flex items-center gap-2">
-              전체
-              <Badge className="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums">
-                {counts.all}
-              </Badge>
-            </span>
-          </TabsTrigger>
-          <TabsTrigger value="active">
-            <span className="flex items-center gap-2">
-              활성
-              <Badge className="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums">
-                {counts.active}
-              </Badge>
-            </span>
-          </TabsTrigger>
-          <TabsTrigger value="inactive">
-            <span className="flex items-center gap-2">
-              비활성
-              <Badge className="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums">
-                {counts.inactive}
-              </Badge>
-            </span>
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value={tab} className="mt-4">
-          <FixedCostsList
-            items={filteredItems}
-            isLoading={isLoading}
-            emptyMessage={emptyMessage}
-            onToggleActive={handleToggleActive}
-            onEdit={handleEditClick}
-          />
-        </TabsContent>
-      </Tabs>
+      <FixedCostsList
+        items={items}
+        isLoading={isLoading}
+        onEdit={handleEditClick}
+      />
     </div>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -6,10 +6,7 @@ import FixedCostsList from './FixedCostsList';
 import ResponsivePanel from '../panel/ResponsivePanel';
 import FixedCostSubmitForm from './FixedCostSubmitForm';
 import { IFixedRule } from '@/types/fixed-costs';
-import {
-  fetchFixedRules,
-  setFixedRuleActive,
-} from '@/services/fixed-costs/fixed-costs';
+import { fetchFixedRules } from '@/services/fixed-costs/fixed-costs';
 import { toast } from 'sonner';
 import { mapFixedRuleToFormData } from '@/utils/fixed-costs';
 

--- a/fe/src/hooks/useFixedCostForm.ts
+++ b/fe/src/hooks/useFixedCostForm.ts
@@ -13,8 +13,6 @@ export interface IFixedCostFormData {
 
   start_date: Date;
   end_date: Date | null;
-
-  is_active: boolean;
 }
 
 const getInitialFormData = (
@@ -31,8 +29,6 @@ const getInitialFormData = (
 
   start_date: initialData?.start_date ?? new Date(),
   end_date: initialData?.end_date ?? null,
-
-  is_active: initialData?.is_active ?? true,
 });
 
 export const useFixedCostForm = (initialData?: Partial<IFixedCostFormData>) => {

--- a/fe/src/services/fixed-costs/fixed-costs.ts
+++ b/fe/src/services/fixed-costs/fixed-costs.ts
@@ -127,3 +127,11 @@ export const fetchActiveFixedRulesByMonth = async (monthDate: Date) => {
   if (error) throw error;
   return (data ?? []) as IFixedRule[];
 };
+
+export const deleteFixedRule = async (ruleId: string) => {
+  const { error } = await supabase
+    .from('fixed_rules')
+    .delete()
+    .eq('id', ruleId);
+  if (error) throw error;
+};

--- a/fe/src/services/fixed-costs/fixed-costs.ts
+++ b/fe/src/services/fixed-costs/fixed-costs.ts
@@ -26,22 +26,6 @@ export const fetchFixedRules = async () => {
   return (data ?? []) as IFixedRule[];
 };
 
-// 고정비 활성화/비활성화 설정
-export const setFixedRuleActive = async (id: string, isActive: boolean) => {
-  const userId = await requireUserId();
-
-  const { data, error } = await supabase
-    .from('fixed_rules')
-    .update({ is_active: isActive })
-    .eq('id', id)
-    .eq('user_id', userId)
-    .select('*')
-    .single();
-
-  if (error) throw error;
-  return data as IFixedRule;
-};
-
 // 고정비 항목 생성
 export const createFixedRule = async (input: CreateFixedRuleInput) => {
   const userId = await requireUserId();
@@ -111,8 +95,8 @@ export const updateFixedRuleThisMonth = async (
   return data ?? [];
 };
 
-// 해당 월에 적용되는 활성 고정비 규칙 조회
-export const fetchActiveFixedRulesByMonth = async (monthDate: Date) => {
+// 해당 월에 적용되는 고정비 규칙 조회
+export const fetchFixedRulesByMonth = async (monthDate: Date) => {
   const userId = await requireUserId();
   const { startDate, endDate } = getMonthRange(monthDate);
 
@@ -120,7 +104,6 @@ export const fetchActiveFixedRulesByMonth = async (monthDate: Date) => {
     .from('fixed_rules')
     .select('*')
     .eq('user_id', userId)
-    .eq('is_active', true)
     .lte('start_date', endDate)
     .or(`end_date.is.null,end_date.gte.${startDate}`);
 
@@ -129,9 +112,13 @@ export const fetchActiveFixedRulesByMonth = async (monthDate: Date) => {
 };
 
 export const deleteFixedRule = async (ruleId: string) => {
+  const userId = await requireUserId();
+
   const { error } = await supabase
     .from('fixed_rules')
     .delete()
-    .eq('id', ruleId);
+    .eq('id', ruleId)
+    .eq('user_id', userId);
+
   if (error) throw error;
 };

--- a/fe/src/services/fixed-costs/getRuleDates.ts
+++ b/fe/src/services/fixed-costs/getRuleDates.ts
@@ -1,7 +1,10 @@
 import { IFixedRule } from '@/types/fixed-costs';
 import { formatLocalDate, getMonthRange } from '@/utils/date';
 
-type RuleForCalc = Pick<IFixedRule, 'cycle' | 'weekday' | 'monthday'>;
+type RuleForCalc = Pick<
+  IFixedRule,
+  'cycle' | 'weekday' | 'monthday' | 'start_date' | 'end_date'
+>;
 
 const toJsWeekday = (weekday: number) => {
   // rule.weekday: 1~7 (월~일)
@@ -16,14 +19,22 @@ export const getFixedRuleDates = (
 ): string[] => {
   const year = monthDate.getFullYear();
   const monthIndex = monthDate.getMonth();
-  const { endDate } = getMonthRange(monthDate);
-  const lastDay = Number(endDate.slice(8, 10));
+  const { startDate: monthStart, endDate: monthEnd } = getMonthRange(monthDate);
+  const lastDay = Number(monthEnd.slice(8, 10));
+
+  // 해당 월에서 유효한 날짜 범위
+  const minDate = rule.start_date > monthStart ? rule.start_date : monthStart;
+  const maxDate =
+    rule.end_date && rule.end_date < monthEnd ? rule.end_date : monthEnd;
 
   // MONTHLY : 해당 날짜(없으면 말일로 당김) 1개만 반환
   if (rule.cycle === 'MONTHLY') {
     if (!rule.monthday) return [];
     const day = Math.min(rule.monthday, lastDay);
-    return [formatLocalDate(new Date(year, monthIndex, day))];
+    const date = formatLocalDate(new Date(year, monthIndex, day));
+
+    if (date < minDate || date > maxDate) return [];
+    return [date];
   }
 
   // WEEKLY : 지정 요일 기준 해당 월의 모든 날짜 반환
@@ -34,9 +45,12 @@ export const getFixedRuleDates = (
 
     for (let d = 1; d <= lastDay; d++) {
       const js = new Date(year, monthIndex, d).getDay();
-      if (js === target) {
-        dates.push(formatLocalDate(new Date(year, monthIndex, d)));
-      }
+      if (js !== target) continue;
+
+      const date = formatLocalDate(new Date(year, monthIndex, d));
+
+      if (date < minDate || date > maxDate) continue;
+      dates.push(date);
     }
     return dates;
   }

--- a/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
@@ -14,13 +14,12 @@ export const syncByMonthClient = async (
 
   return syncByMonthShared(
     {
-      // 해당 월에 유효한 활성 고정비 규칙 조회
+      // 해당 월에 유효한 고정비 규칙 조회
       fetchActiveRules: async ({ userId, startDate, endDate }) => {
         const { data, error } = await supabase
           .from('fixed_rules')
           .select('*')
           .eq('user_id', userId)
-          .eq('is_active', true)
           .lte('start_date', endDate)
           .or(`end_date.is.null,end_date.gte.${startDate}`);
 

--- a/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
@@ -15,7 +15,7 @@ export const syncByMonthClient = async (
   return syncByMonthShared(
     {
       // 해당 월에 유효한 고정비 규칙 조회
-      fetchActiveRules: async ({ userId, startDate, endDate }) => {
+      fetchFixedRules: async ({ userId, startDate, endDate }) => {
         const { data, error } = await supabase
           .from('fixed_rules')
           .select('*')

--- a/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
@@ -24,13 +24,12 @@ export const syncByMonthServer = async ({
 
   return syncByMonthShared(
     {
-      // 해당 월에 유효한 활성 고정비 규칙 조회
+      // 해당 월에 유효한 고정비 규칙 조회
       fetchActiveRules: async ({ userId, startDate, endDate }) => {
         const { data, error } = await supabase
           .from('fixed_rules')
           .select('*')
           .eq('user_id', userId)
-          .eq('is_active', true)
           .lte('start_date', endDate)
           .or(`end_date.is.null,end_date.gte.${startDate}`);
 

--- a/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
@@ -25,7 +25,7 @@ export const syncByMonthServer = async ({
   return syncByMonthShared(
     {
       // 해당 월에 유효한 고정비 규칙 조회
-      fetchActiveRules: async ({ userId, startDate, endDate }) => {
+      fetchFixedRules: async ({ userId, startDate, endDate }) => {
         const { data, error } = await supabase
           .from('fixed_rules')
           .select('*')

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -2,7 +2,7 @@ import type { FixedTransactionInsert, IFixedRule } from '@/types/fixed-costs';
 import { getFixedRuleDates } from './getRuleDates';
 
 type SyncDeps = {
-  fetchActiveRules: (args: {
+  fetchFixedRules: (args: {
     userId: string;
     startDate: string;
     endDate: string;
@@ -93,7 +93,7 @@ export const syncByMonthShared = async (
       : endDate;
 
   // 해당 월에 유효한 고정비 규칙 조회
-  const rules = await deps.fetchActiveRules({
+  const rules = await deps.fetchFixedRules({
     userId,
     startDate,
     endDate: effectiveEndDate,

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -96,7 +96,7 @@ export const syncByMonthShared = async (
   const rules = await deps.fetchFixedRules({
     userId,
     startDate,
-    endDate: effectiveEndDate,
+    endDate,
   });
   if (rules.length === 0) return { createdCount: 0 };
 

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -14,7 +14,6 @@ export interface IFixedRule {
   monthday: number | null;
   start_date: string;
   end_date: string | null;
-  is_active: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/fe/src/utils/fixed-costs.ts
+++ b/fe/src/utils/fixed-costs.ts
@@ -43,6 +43,4 @@ export const mapFixedRuleToFormData = (
 
   start_date: parseLocalDate(rule.start_date),
   end_date: rule.end_date ? parseLocalDate(rule.end_date) : null,
-
-  is_active: rule.is_active,
 });


### PR DESCRIPTION
## PR 개요

- 고정비 규칙의 **활성/비활성 개념을 제거**하고, 규칙은 **수정/삭제만 가능한 구조**로 단순화했습니다.
- 고정비 규칙 삭제 시에는 규칙만 제거하고, 해당 규칙으로 생성된 거래는 **유지하되 규칙 연결만 해제**되도록 구현했습니다.

## 변경 사항

- 고정비 규칙 삭제 기능 구현
    - 규칙 삭제 시 `fixed_rules` row 삭제
    - 기존 거래는 유지되며 `fixed_rule_id`는 `null`로 해제 
    (FK `ON DELETE SET NULL`)
- 고정비 활성/비활성(`is_active`) 기능 전면 제거
    - 활성/비활성 탭, 토글 UI 제거
    - 관련 상태/필터/카운트 로직 제거
- 고정비 서비스 및 타입에서 `is_active` 제거
    - 조회/수정/동기화 로직에서 active 조건 제거
    - 거래 생성 로직에서 활성 여부가 아닌 날짜 범위 기준으로 적용 규칙 판단
    - 고정비 규칙 조회 함수 active 의미 제거
- 고정비 발생 날짜 계산 로직 수정
  - 규칙 시작일(start_date) 이전 날짜의 거래가 생성되던 버그 수정

## 스크린샷 (선택)

<img width="450" height="392" alt="image" src="https://github.com/user-attachments/assets/0201ebae-dbd0-4427-8f57-b41b6e88be64" />
<img width="450" height="298" alt="image" src="https://github.com/user-attachments/assets/ae8539e1-2844-40ac-bc7b-45a13b4e8476" />

## 리뷰 요청 사항
- 고정비 규칙 삭제 기능이 정상적으로 작동하는지 확인 부탁드립니다.

## 추후 할 일
- [ ] 고정비 수정 기능 개선 #47 

