### PR TITLE
[feat] 고정비 규칙 수정 적용 범위 개선 및 폼 UI 정렬

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -28,6 +28,7 @@
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
     "next": "^16.1.0",
     "next-themes": "^0.4.6",

--- a/fe/src/app/globals.css
+++ b/fe/src/app/globals.css
@@ -123,3 +123,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+.scrollbar-hide {
+  -ms-overflow-style: none; /* IE, Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none; /* Chrome, Safari */
+}

--- a/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
@@ -36,14 +36,28 @@ export default function FixedCostEditConfirmDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="mt-4 flex flex-col gap-2">
-          <Button variant="outline" onClick={onApplyIncludeCurrent}>
-            {unit} 포함 이후 전부 적용
-          </Button>
+        <div className="mt-3 flex flex-col gap-3">
+          <div className="rounded-md border p-3">
+            <Button className="w-full" onClick={onApplyIncludeCurrent}>
+              {unit} 포함 이후 전부 적용
+            </Button>
+            <p className="text-muted-foreground mt-1 text-sm">
+              이미 생성된 {unit} 거래도 새 규칙으로 수정됩니다.
+            </p>
+          </div>
 
-          <Button variant="outline" onClick={onApplyExcludeCurrent}>
-            {unit} 제외 이후 전부 적용
-          </Button>
+          <div className="rounded-md border p-3">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={onApplyExcludeCurrent}
+            >
+              {unit} 제외 이후 전부 적용
+            </Button>
+            <p className="text-muted-foreground mt-1 text-sm">
+              {unit} 거래는 유지되고 다음 기간부터 적용됩니다.
+            </p>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
@@ -12,16 +12,20 @@ import { Button } from '@/components/ui/button';
 type FixedCostEditConfirmDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onApplyThisMonth: () => void;
-  onApplyFuture: () => void;
+  cycle: 'WEEKLY' | 'MONTHLY';
+  onApplyIncludeCurrent: () => void;
+  onApplyExcludeCurrent: () => void;
 };
 
 export default function FixedCostEditConfirmDialog({
   open,
   onOpenChange,
-  onApplyThisMonth,
-  onApplyFuture,
+  cycle,
+  onApplyIncludeCurrent,
+  onApplyExcludeCurrent,
 }: FixedCostEditConfirmDialogProps) {
+  const unit = cycle === 'WEEKLY' ? '이번주' : '이번달';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -33,11 +37,12 @@ export default function FixedCostEditConfirmDialog({
         </DialogHeader>
 
         <div className="mt-4 flex flex-col gap-2">
-          <Button variant="outline" onClick={onApplyThisMonth}>
-            이번 달만 적용
+          <Button variant="outline" onClick={onApplyIncludeCurrent}>
+            {unit} 포함 이후 전부 적용
           </Button>
-          <Button variant="outline" onClick={onApplyFuture}>
-            이후 전부 적용
+
+          <Button variant="outline" onClick={onApplyExcludeCurrent}>
+            {unit} 제외 이후 전부 적용
           </Button>
         </div>
       </DialogContent>

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -139,47 +139,52 @@ export default function FixedCostSubmitForm({
   };
 
   return (
-    <div className="flex h-full flex-col px-6">
-      <form onSubmit={handleSubmit} className="flex h-full flex-col space-y-6">
-        <div className="border-b pb-4">
+    <div className="flex min-h-dvh flex-col px-6">
+      <form
+        onSubmit={handleSubmit}
+        className="mx-auto flex min-h-dvh w-full flex-col p-10 pt-2"
+      >
+        <div className="sticky top-0 flex items-center justify-between border-b pb-4">
           <Label className="text-xl">
             {mode === 'create' ? '고정비 추가' : '고정비 수정'}
           </Label>
         </div>
 
-        <TitleInput
-          value={formData.title}
-          onChange={(title) => UpdateField('title', title)}
-        />
+        <div className="scrollbar-hide flex-1 space-y-6 overflow-y-auto pt-6 pb-24">
+          <TitleInput
+            value={formData.title}
+            onChange={(title) => UpdateField('title', title)}
+          />
 
-        <TypeSelector
-          value={formData.type}
-          onChange={(type) => {
-            UpdateField('type', type);
-            UpdateField('category_id', '');
-          }}
-        />
+          <TypeSelector
+            value={formData.type}
+            onChange={(type) => {
+              UpdateField('type', type);
+              UpdateField('category_id', '');
+            }}
+          />
 
-        <CategorySelector
-          transactionType={formData.type}
-          value={formData.category_id}
-          open={categoryOpen}
-          onOpenChange={setCategoryOpen}
-          onChange={(category) => UpdateField('category_id', category)}
-        />
+          <CategorySelector
+            transactionType={formData.type}
+            value={formData.category_id}
+            open={categoryOpen}
+            onOpenChange={setCategoryOpen}
+            onChange={(category) => UpdateField('category_id', category)}
+          />
 
-        <AmountInput
-          value={formData.amount}
-          onChange={(amount) => UpdateField('amount', amount)}
-        />
+          <AmountInput
+            value={formData.amount}
+            onChange={(amount) => UpdateField('amount', amount)}
+          />
 
-        {/* 고정비 영역 */}
-        <FixedCostScheduleFields
-          formData={formData}
-          UpdateField={UpdateField}
-        />
+          {/* 고정비 영역 */}
+          <FixedCostScheduleFields
+            formData={formData}
+            UpdateField={UpdateField}
+          />
+        </div>
 
-        <div className="mt-auto border-t pt-4 pb-4">
+        <div className="bg-background sticky bottom-0 border-t pt-4 pb-4">
           {mode === 'create' ? (
             <Button type="submit" className="w-full">
               저장

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -14,8 +14,7 @@ import { formatLocalDate } from '@/utils/date';
 import {
   createFixedRule,
   deleteFixedRule,
-  updateFixedRule,
-  updateFixedRuleThisMonth,
+  updateFixedRuleWithScope,
 } from '@/services/fixed-costs/fixed-costs';
 import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
@@ -84,47 +83,44 @@ export default function FixedCostSubmitForm({
     }
   };
 
-  const handleApplyFuture = async () => {
+  const closeConfirm = () => {
+    setConfirmOpen(false);
+    setPendingPayload(null);
+  };
+
+  const handleApplyIncludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
 
     try {
-      await updateFixedRule(ruleId, pendingPayload);
+      await updateFixedRuleWithScope({
+        id: ruleId,
+        ruleInput: pendingPayload,
+        scope: 'INCLUDE_CURRENT',
+      });
+
       toast.success('고정비가 수정되었습니다.');
-
-      setConfirmOpen(false);
-      setPendingPayload(null);
-
+      closeConfirm();
       onSuccess();
     } catch {
       toast.error('고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
     }
   };
 
-  const handleApplyThisMonth = async () => {
+  const handleApplyExcludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
 
     try {
-      const updated = await updateFixedRuleThisMonth(ruleId, {
-        title: pendingPayload.title,
-        type: pendingPayload.type,
-        amount: pendingPayload.amount,
-        category_id: pendingPayload.category_id,
+      await updateFixedRuleWithScope({
+        id: ruleId,
+        ruleInput: pendingPayload,
+        scope: 'EXCLUDE_CURRENT',
       });
 
-      if (updated.length === 0) {
-        toast('이번 달에 생성된 고정비 거래가 없습니다.');
-      } else {
-        toast.success('이번 달 고정비 거래가 수정되었습니다.');
-      }
-
-      setConfirmOpen(false);
-      setPendingPayload(null);
-
+      toast.success('고정비가 수정되었습니다.');
+      closeConfirm();
       onSuccess();
     } catch {
-      toast.error(
-        '이번 달 고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.'
-      );
+      toast.error('고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
     }
   };
 
@@ -202,8 +198,9 @@ export default function FixedCostSubmitForm({
       <FixedCostEditConfirmDialog
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
-        onApplyThisMonth={handleApplyThisMonth}
-        onApplyFuture={handleApplyFuture}
+        cycle={formData.cycle as 'WEEKLY' | 'MONTHLY'}
+        onApplyIncludeCurrent={handleApplyIncludeCurrent}
+        onApplyExcludeCurrent={handleApplyExcludeCurrent}
       />
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostsScheduleFields.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsScheduleFields.tsx
@@ -29,8 +29,8 @@ export default function FixedCostScheduleFields({
   return (
     <>
       {/* 시작일 */}
-      <div className="space-y-2">
-        <Label>시작일</Label>
+      <div className="flex">
+        <Label className="w-28 pr-2">시작일</Label>
         <DatePicker
           value={formData.start_date}
           onChange={(date) => UpdateField('start_date', date)}
@@ -49,7 +49,9 @@ export default function FixedCostScheduleFields({
             }}
           />
         </div>
-
+        <p className="text-muted-foreground text-xs">
+          종료일을 설정하려면 오른쪽 스위치를 켜세요.
+        </p>
         {formData.end_date && (
           <DatePicker
             value={formData.end_date}
@@ -57,16 +59,12 @@ export default function FixedCostScheduleFields({
             hideLabel
           />
         )}
-
-        <p className="text-muted-foreground text-xs">
-          종료일을 설정하려면 오른쪽 스위치를 켜세요.
-        </p>
       </div>
 
       {/* 반복 주기 */}
-      <div className="space-y-2">
-        <Label>반복 주기</Label>
-        <div className="grid grid-cols-2 gap-4">
+      <div className="flex items-center space-y-2">
+        <Label className="w-28 pr-2">반복 주기</Label>
+        <div className="grid w-full grid-cols-2 gap-4">
           <button
             type="button"
             onClick={() => {
@@ -105,8 +103,8 @@ export default function FixedCostScheduleFields({
 
       {/* 주간 : 요일 버튼 */}
       {formData.cycle === 'WEEKLY' && (
-        <div className="space-y-2">
-          <Label>반복 요일</Label>
+        <div className="space-y-5">
+          <Label className="w-28 pr-2">반복 요일</Label>
           <div className="grid grid-cols-7 gap-2">
             {WEEKDAYS.map((d) => (
               <button
@@ -129,28 +127,29 @@ export default function FixedCostScheduleFields({
 
       {/* 월간 : 날짜 Select */}
       {formData.cycle === 'MONTHLY' && (
-        <div className="space-y-2">
-          <Label>반복 날짜</Label>
-          <Select
-            value={formData.monthday ? String(formData.monthday) : ''}
-            onValueChange={(v) => UpdateField('monthday', Number(v))}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="날짜를 선택해주세요" />
-            </SelectTrigger>
-            <SelectContent>
-              {MONTH_DAYS.map((d) => (
-                <SelectItem key={d} value={String(d)}>
-                  {d}일
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
+        <>
+          <div className="flex items-center">
+            <Label className="w-28 pr-2">반복 날짜</Label>
+            <Select
+              value={formData.monthday ? String(formData.monthday) : ''}
+              onValueChange={(v) => UpdateField('monthday', Number(v))}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="날짜를 선택해주세요" />
+              </SelectTrigger>
+              <SelectContent>
+                {MONTH_DAYS.map((d) => (
+                  <SelectItem key={d} value={String(d)}>
+                    {d}일
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <p className="text-muted-foreground text-xs">
             29~31일은 해당 월에 날짜가 없으면 말일로 자동 조정돼요.
           </p>
-        </div>
+        </>
       )}
     </>
   );

--- a/fe/src/services/fixed-costs/fixed-costs.ts
+++ b/fe/src/services/fixed-costs/fixed-costs.ts
@@ -1,6 +1,10 @@
 import { supabase } from '@/utils/supabase/client';
-import type { CreateFixedRuleInput, IFixedRule } from '@/types/fixed-costs';
-import { getMonthRange } from '@/utils/date';
+import type {
+  ApplyScope,
+  CreateFixedRuleInput,
+  IFixedRule,
+} from '@/types/fixed-costs';
+import { getMonthRange, getWeekRange } from '@/utils/date';
 
 export const requireUserId = async () => {
   const {
@@ -12,7 +16,7 @@ export const requireUserId = async () => {
   return user.id;
 };
 
-// 고정비 목록 조회
+// 고정비 규칙 목록 조회
 export const fetchFixedRules = async () => {
   const userId = await requireUserId();
 
@@ -26,7 +30,7 @@ export const fetchFixedRules = async () => {
   return (data ?? []) as IFixedRule[];
 };
 
-// 고정비 항목 생성
+// 고정비 규칙 생성
 export const createFixedRule = async (input: CreateFixedRuleInput) => {
   const userId = await requireUserId();
 
@@ -45,7 +49,7 @@ export const createFixedRule = async (input: CreateFixedRuleInput) => {
   return data as IFixedRule;
 };
 
-// 고정비 항목 수정
+// 고정비 규칙 수정
 export const updateFixedRule = async (
   id: string,
   input: CreateFixedRuleInput
@@ -64,18 +68,34 @@ export const updateFixedRule = async (
   return data as IFixedRule;
 };
 
-type UpdateFixedThisMonthInput = Pick<
+type UpdateFixedRuleInPeriod = Pick<
   CreateFixedRuleInput,
   'title' | 'type' | 'amount' | 'category_id'
 >;
 
-// 이번 달에 생성된 고정비 거래만 수정
-export const updateFixedRuleThisMonth = async (
-  fixedRuleId: string,
-  input: UpdateFixedThisMonthInput
-) => {
+// cycle 기준으로 "이번 기간"의 날짜 범위를 반환
+function getCurrentPeriod(cycle: IFixedRule['cycle']) {
+  return cycle === 'MONTHLY'
+    ? getMonthRange(new Date()) // 이번달 범위
+    : getWeekRange(new Date()); // 이번주 범위
+}
+
+// '포함' 옵션일 때, 이번달/이번주에 생성된 고정비 거래를 새 규칙 값으로 동기화
+export const updateFixedRuleInPeriod = async ({
+  fixedRuleId,
+  cycle,
+  input,
+  scope,
+}: {
+  fixedRuleId: string;
+  cycle: IFixedRule['cycle'];
+  input: UpdateFixedRuleInPeriod;
+  scope: ApplyScope;
+}) => {
+  if (scope === 'EXCLUDE_CURRENT') return [];
+
   const userId = await requireUserId();
-  const { startDate, endDate } = getMonthRange(new Date());
+  const { startDate, endDate } = getCurrentPeriod(cycle);
 
   const { data, error } = await supabase
     .from('transactions')
@@ -95,6 +115,35 @@ export const updateFixedRuleThisMonth = async (
   return data ?? [];
 };
 
+// 고정비 규칙 수정 + 적용 범위에 따른 거래 동기화 처리
+export const updateFixedRuleWithScope = async ({
+  id,
+  ruleInput,
+  scope,
+}: {
+  id: string;
+  ruleInput: CreateFixedRuleInput;
+  scope: ApplyScope;
+}) => {
+  // 규칙 row 업데이트
+  const updatedRule = await updateFixedRule(id, ruleInput);
+
+  // 포함이면 이번 기간 거래 업데이트
+  await updateFixedRuleInPeriod({
+    fixedRuleId: id,
+    cycle: updatedRule.cycle,
+    input: {
+      title: updatedRule.title,
+      type: updatedRule.type,
+      amount: updatedRule.amount,
+      category_id: updatedRule.category_id,
+    },
+    scope,
+  });
+
+  return updatedRule;
+};
+
 // 해당 월에 적용되는 고정비 규칙 조회
 export const fetchFixedRulesByMonth = async (monthDate: Date) => {
   const userId = await requireUserId();
@@ -111,6 +160,7 @@ export const fetchFixedRulesByMonth = async (monthDate: Date) => {
   return (data ?? []) as IFixedRule[];
 };
 
+// 고정비 항목 삭제
 export const deleteFixedRule = async (ruleId: string) => {
   const userId = await requireUserId();
 

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -1,5 +1,6 @@
 export type FixedCostType = 'income' | 'expense' | '';
 export type FixedCostCycle = 'WEEKLY' | 'MONTHLY' | '';
+export type ApplyScope = 'INCLUDE_CURRENT' | 'EXCLUDE_CURRENT';
 
 // 고정비 테이블 항목 타입
 export interface IFixedRule {

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { startOfWeek, endOfWeek } from 'date-fns';
+
 /** 선택된 날짜를 바탕으로 해당 월의 시작일과 종료일을 YYYY-MM-DD 형식으로 반환 */
 export const getMonthRange = (date: Date) => {
   const year = date.getFullYear();
@@ -11,6 +13,17 @@ export const getMonthRange = (date: Date) => {
   const endDate = `${year}-${formatMonth}-${String(lastDay).padStart(2, '0')}`;
 
   return { startDate, endDate };
+};
+
+// 선택된 날짜 기준 주 범위 (월요일 시작)
+export const getWeekRange = (date: Date) => {
+  const start = startOfWeek(date, { weekStartsOn: 1 });
+  const end = endOfWeek(date, { weekStartsOn: 1 });
+
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  };
 };
 
 // Date 객체를 'YYYY-MM-DD' 문자열로 변환
@@ -28,8 +41,8 @@ export const formatDateKR = (date: Date) => {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}년 ${month}월 ${day}일`;
 };
-// 'YYYY-MM-DD' 문자열을 로컬 Date로 변환 (시간 00:00 고정)
 
+// 'YYYY-MM-DD' 문자열을 로컬 Date로 변환 (시간 00:00 고정)
 export const parseLocalDate = (value?: string | null): Date | undefined => {
   if (!value) return undefined;
 

--- a/fe/src/utils/fixed-costs.ts
+++ b/fe/src/utils/fixed-costs.ts
@@ -1,6 +1,14 @@
 import { IFixedCostFormData } from '@/hooks/useFixedCostForm';
-import { IFixedRule } from '@/types/fixed-costs';
+import { ApplyScope, IFixedRule } from '@/types/fixed-costs';
 import { parseLocalDate } from './date';
+import {
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addMonths,
+  addWeeks,
+} from 'date-fns';
 
 const WEEKDAY_LABEL: Record<number, string> = {
   1: '월',
@@ -44,3 +52,46 @@ export const mapFixedRuleToFormData = (
   start_date: parseLocalDate(rule.start_date),
   end_date: rule.end_date ? parseLocalDate(rule.end_date) : null,
 });
+
+// 고정비 규칙 수정 시 적용 시작 기준 날짜 (오늘 기준)
+export const getRuleApplyStartDate = ({
+  cycle,
+  scope,
+  today = new Date(),
+}: {
+  cycle: 'MONTHLY' | 'WEEKLY';
+  scope: ApplyScope;
+  today?: Date;
+}): Date => {
+  if (cycle === 'MONTHLY') {
+    return scope === 'INCLUDE_CURRENT'
+      ? startOfMonth(today)
+      : startOfMonth(addMonths(today, 1));
+  }
+
+  // WEEKLY (월요일 시작)
+  return scope === 'INCLUDE_CURRENT'
+    ? startOfWeek(today, { weekStartsOn: 1 })
+    : startOfWeek(addWeeks(today, 1), { weekStartsOn: 1 });
+};
+
+// '포함' 옵션에서 기존 거래를 수정할 대상 기간 (오늘 기준)
+export const getRuleApplyRange = ({
+  cycle,
+  today = new Date(),
+}: {
+  cycle: 'MONTHLY' | 'WEEKLY';
+  today?: Date;
+}) => {
+  if (cycle === 'MONTHLY') {
+    return {
+      from: startOfMonth(today),
+      to: endOfMonth(today),
+    };
+  }
+
+  return {
+    from: startOfWeek(today, { weekStartsOn: 1 }),
+    to: endOfWeek(today, { weekStartsOn: 1 }),
+  };
+};


### PR DESCRIPTION
## PR 개요

- 고정비 규칙 수정 시 월간/주간 반복 규칙에 따라 이번달(이번주) 포함/제외 이후 전부 적용 옵션을 제공하도록 개선했습니다.
- 고정비 입력 폼 UI를 팀에서 사용하는 공통 입력 레이아웃에 맞게 정렬하여 폼 전반의 일관성을 개선했습니다.

## 변경 사항
### 1. 고정비 규칙 수정 적용 범위 로직 개선
- 고정비 규칙 수정 시 적용 범위를 `INCLUDE_CURRENT / EXCLUDE_CURRENT`로 명확히 분리
- `INCLUDE_CURRENT` 선택 시
    - 이번달/이번주에 이미 생성된 고정비 거래를 새 규칙 값으로 update
- `EXCLUDE_CURRENT` 선택 시
    - 현재 기간 거래는 유지하고 이후 기간부터 새 규칙 적용
- 월간(MONTHLY) / 주간(WEEKLY) 반복 규칙에 따라 적용 기간 계산 분기 처리

### 2. 고정비 수정 적용 범위 선택 UI 개선
- 수정 확인 다이얼로그 문구를 반복 주기에 따라 분기
    - 월간 : `이번달 포함/제외 이후 전부 적용`
    - 주간 : `이번주 포함/제외 이후 전부 적용`
- 적용 범위 선택 의미를 명확히 드러내도록 버튼 라벨 개선

### 3. 고정비 수정 폼 로직 정리
- 고정비 수정 시 호출 로직을 `updateFixedRuleWithScope`로 통합
- 기존 월 단위 전용 수정 함수 제거
- 규칙 수정 + 거래 동기화 흐름을 하나의 인터페이스로 정리

### 4. 고정비 입력 폼 UI 정렬 및 디자인 통일
- 고정비 입력 폼을 팀에서 사용하는 공통 입력 컴포넌트 레이아웃에 맞게 정렬
- 라벨 고정 폭 + 입력 영역 분리 구조로 폼 레이아웃 통일
- 모바일 환경에서 입력 영역 스크롤 및 하단 버튼 접근성 개선
  - `globals.css`에 추가된 `.scrollbar-hide` 유틸을 사용해 스크롤바 노출 최소화
## 스크린샷
<img width="350" height="696" alt="image" src="https://github.com/user-attachments/assets/fd9894ef-c7f0-4a12-a4c1-5faa97494a6b" />
<img width="350" height="338" alt="스크린샷 2026-01-04 00 25 53" src="https://github.com/user-attachments/assets/97e77a0c-65d4-4a5c-818b-ffbe475302f5" />

## 리뷰 요청 사항
- 고정비 규칙 수정 시 적용 범위 옵션(이번달/이번주 포함·제외)이 의도한 대로 동작하는지 확인 부탁드립니다.
  - 포함 선택 시 : 이미 생성된 현재 기간(이번달/이번주) 거래가 새 규칙 값으로 수정되는지
  - 제외 선택 시 : 현재 기간 거래는 유지되고, 이후 기간부터 새 규칙이 적용되는지