### PR TITLE
[feat] 캘린더 + Panel 내부 가계부 CRUD 연동

### DIFF
--- a/fe/src/app/(app)/history/actions.ts
+++ b/fe/src/app/(app)/history/actions.ts
@@ -87,4 +87,5 @@ export const getTransaction = async (
 
 export async function revalidateTransactions() {
   revalidatePath('/history');
+  revalidatePath('/');
 }

--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -4,6 +4,7 @@ import { TransactionFilters } from './actions';
 import { getTransaction } from './actions';
 import { Suspense } from 'react';
 import { TransactionProvider } from './TransactionContext';
+import { TransactionListSkeleton } from '@/components/transaction/TransactionListSkeleton';
 interface PageProps {
   searchParams: Promise<{
     type?: string;
@@ -27,7 +28,7 @@ export default async function Page({ searchParams }: PageProps) {
     <>
       <TransactionProvider>
         <div className="flex h-screen w-full flex-col">
-          <Suspense fallback={<div>skeleton ui</div>}>
+          <Suspense fallback={<TransactionListSkeleton />}>
             <TransactionListWrapper filters={filters} />
           </Suspense>
           <TransactionClient />

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -6,6 +6,7 @@ import { formatMonth } from '@/utils/date';
 import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
+import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -29,7 +30,7 @@ export default async function Home({ searchParams }: PageProps) {
     <div className="flex w-full max-w-6xl">
       <TransactionProvider>
         <CalendarProvider>
-          <Suspense fallback={<div>skeleton</div>}>
+          <Suspense fallback={<CalendarSkeleton />}>
             <DataCalendar
               filters={filters}
               currentMonth={currentMonth}

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -27,7 +27,7 @@ export default async function Home({ searchParams }: PageProps) {
   };
 
   return (
-    <div className="flex w-full max-w-6xl">
+    <div className="flex w-full max-w-6xl self-start min-h-[900px]">
       <TransactionProvider>
         <CalendarProvider>
           <Suspense fallback={<CalendarSkeleton />}>

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -13,11 +13,12 @@ import { CaptionLabelProps } from 'react-day-picker';
 import { formatDateKR, formatLocalDate } from '@/utils/date';
 import { Card, CardTitle, CardContent } from '../ui/card';
 import { MonthCaptionProps } from 'react-day-picker';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
 import { TransactionList } from '../transaction/TransactionList';
 import { formatMonth } from '@/utils/date';
 import TransactionSubmitForm from '../transaction/TransactionSubmitForm';
 import { revalidateTransactions } from '@/app/(app)/history/actions';
+import { Item, ItemContent } from '../ui/item';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
@@ -251,12 +252,23 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
           </h3>
 
           {panelState.view === 'list' && (
-            <div className="space-y-2">
+            <div>
+              <div className="space-y-2 p-4 md:p-6 lg:p-8">
+                <Item
+                  className="cursor-pointer hover:bg-gray-100"
+                  variant="outline"
+                  onClick={() => {
+                    setPanelState({ view: 'create' });
+                  }}
+                >
+                  <Plus />
+                  <ItemContent>가계부 작성하기</ItemContent>
+                </Item>
+              </div>
               <TransactionList
                 compact={true}
                 transactions={selectedDayTransactions}
                 onEdit={(tx) => {
-                  console.log('edit!');
                   setPanelState({ view: 'edit', editingTransaction: tx });
                 }}
                 onCreate={() => {
@@ -286,6 +298,31 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
                   setPanelState({ view: 'list' });
                 }}
                 mode="edit"
+              />
+            </div>
+          )}
+
+          {panelState.view === 'create' && (
+            <div className="space-y-2">
+              <Button
+                onClick={() => {
+                  setPanelState({ view: 'list' });
+                }}
+                className="m-4 ml-6 flex"
+              >
+                <ChevronLeft />
+                목록으로
+              </Button>
+              <TransactionSubmitForm
+                defaultDate={selectedDate ?? undefined}
+                onSuccess={async () => {
+                  await revalidateTransactions();
+                  setPanelState({ view: 'list' });
+                }}
+                onClose={() => {
+                  setPanelState({ view: 'list' });
+                }}
+                mode="create"
               />
             </div>
           )}

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -173,6 +173,10 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
   const year = month.getFullYear();
   const displayMonth = month.getMonth() + 1;
 
+  const handleClose = () => {
+    close();
+    setPanelState({ view: 'list' });
+  };
   const CustomCaption = (props: MonthCaptionProps) => {
     return (
       <div className="flex w-full gap-2 p-2 sm:flex-row sm:gap-4">
@@ -240,7 +244,7 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
         }}
         disableNavigation
       />
-      <ResponsivePanel isOpen={isOpen} setIsOpen={close}>
+      <ResponsivePanel isOpen={isOpen} setIsOpen={handleClose}>
         <div className="space-y-4">
           <h3 className="pl-8 text-lg font-semibold">
             {selectedDate && formatDateKR(selectedDate)}
@@ -263,6 +267,15 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
           )}
           {panelState.view === 'edit' && (
             <div className="space-y-2">
+              <Button
+                onClick={() => {
+                  setPanelState({ view: 'list' });
+                }}
+                className="m-4 ml-6 flex"
+              >
+                <ChevronLeft />
+                목록으로
+              </Button>
               <TransactionSubmitForm
                 transaction={panelState.editingTransaction}
                 onSuccess={async () => {

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -16,6 +16,7 @@ import { MonthCaptionProps } from 'react-day-picker';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { TransactionList } from '../transaction/TransactionList';
 import { formatMonth } from '@/utils/date';
+import TransactionSubmitForm from '../transaction/TransactionSubmitForm';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
@@ -25,6 +26,10 @@ interface DayData {
   income: number;
   expense: number;
   transactions: ITransaction[];
+}
+interface PanelState {
+  view: 'list' | 'create' | 'edit';
+  editingTransaction?: ITransaction;
 }
 
 const CALENDAR_CELL_HEIGHT =
@@ -85,6 +90,8 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
   const [month, setMonth] = useState<Date>(new Date(`${currentMonth}-01`));
   const [date, setDate] = useState<Date | undefined>(new Date());
   const { selectedDate, isOpen, open, close } = useCalendar();
+
+  const [panelState, setPanelState] = useState<PanelState>({ view: 'list' });
 
   useEffect(() => {
     setMonth(new Date(`${currentMonth}-01`));
@@ -238,15 +245,32 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
             {selectedDate && formatDateKR(selectedDate)}
           </h3>
 
-          {selectedDayTransactions.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
-              거래 내역이 없습니다.
-            </p>
-          ) : (
+          {panelState.view === 'list' && (
             <div className="space-y-2">
               <TransactionList
                 compact={true}
                 transactions={selectedDayTransactions}
+                onEdit={(tx) => {
+                  console.log('edit!');
+                  setPanelState({ view: 'edit', editingTransaction: tx });
+                }}
+                onCreate={() => {
+                  setPanelState({ view: 'create' });
+                }}
+              />
+            </div>
+          )}
+          {panelState.view === 'edit' && (
+            <div className="space-y-2">
+              <TransactionSubmitForm
+                transaction={panelState.editingTransaction}
+                onSuccess={() => {
+                  setPanelState({ view: 'list' });
+                }}
+                onClose={() => {
+                  setPanelState({ view: 'list' });
+                }}
+                mode="edit"
               />
             </div>
           )}

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -17,6 +17,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { TransactionList } from '../transaction/TransactionList';
 import { formatMonth } from '@/utils/date';
 import TransactionSubmitForm from '../transaction/TransactionSubmitForm';
+import { revalidateTransactions } from '@/app/(app)/history/actions';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
@@ -264,7 +265,8 @@ export const Calendar = ({ currentMonth, transactions }: CalendarProps) => {
             <div className="space-y-2">
               <TransactionSubmitForm
                 transaction={panelState.editingTransaction}
-                onSuccess={() => {
+                onSuccess={async () => {
+                  await revalidateTransactions();
                   setPanelState({ view: 'list' });
                 }}
                 onClose={() => {

--- a/fe/src/components/calendar/CalendarSkeleton.tsx
+++ b/fe/src/components/calendar/CalendarSkeleton.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function CalendarSkeleton() {
+  return (
+    <div className="flex w-full flex-col items-center">
+      <div className="flex flex-col items-center justify-center py-6 md:py-10">
+        <Skeleton className="mb-2 h-4 w-12" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-md" />
+          <Skeleton className="h-8 w-16" />
+          <Skeleton className="h-10 w-10 rounded-md" />
+        </div>
+      </div>
+
+      <div className="flex w-full gap-2 p-2 sm:gap-4">
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <Skeleton className="h-16 w-full rounded-xl" />
+      </div>
+      <div className="w-full rounded-md border p-2">
+        <div className="mb-2 grid grid-cols-7 gap-1">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full" />
+          ))}
+        </div>
+
+        {Array.from({ length: 6 }).map((_, week) => (
+          <div key={week} className="mb-1 grid grid-cols-7 gap-1">
+            {Array.from({ length: 7 }).map((_, day) => (
+              <Skeleton
+                key={day}
+                className="h-[60px] w-full rounded-md sm:h-[70px] md:h-[80px]"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/components/transaction/TransactionItem.tsx
+++ b/fe/src/components/transaction/TransactionItem.tsx
@@ -12,11 +12,15 @@ import { cn } from '@/lib/utils';
 import { formatDateKR } from '@/utils/date';
 import { CATEGORIES } from '@/constants/categories';
 import { useSelected } from '@/app/(app)/history/TransactionContext';
+
+interface TransactionItemProps {
+  transaction: ITransaction;
+  onEdit?: (tx: ITransaction) => void;
+}
 export const TransactionItem = ({
   transaction,
-}: {
-  transaction: ITransaction;
-}) => {
+  onEdit,
+}: TransactionItemProps) => {
   const { openEdit } = useSelected();
   return (
     <Item variant="outline">
@@ -49,7 +53,12 @@ export const TransactionItem = ({
           <Button
             className="cursor-pointer"
             size="sm"
-            onClick={() => openEdit(transaction)}
+            onClick={() => {
+              if (onEdit) {
+                onEdit(transaction);
+              }
+              openEdit(transaction);
+            }}
           >
             <ChevronRight />
           </Button>

--- a/fe/src/components/transaction/TransactionList.tsx
+++ b/fe/src/components/transaction/TransactionList.tsx
@@ -6,11 +6,15 @@ import { TransactionFilter } from './TransactionFilter';
 interface TransactionListProps {
   transactions: ITransaction[];
   compact?: boolean;
+  onEdit?: (tx: ITransaction) => void;
+  onCreate?: () => void;
 }
 
 export const TransactionList = ({
   transactions,
   compact = false,
+  onEdit,
+  onCreate,
 }: TransactionListProps) => {
   if (compact) {
     return (
@@ -22,7 +26,11 @@ export const TransactionList = ({
             </p>
           ) : (
             transactions.map((transaction) => (
-              <TransactionItem key={transaction.id} transaction={transaction} />
+              <TransactionItem
+                key={transaction.id}
+                transaction={transaction}
+                onEdit={onEdit}
+              />
             ))
           )}
         </div>

--- a/fe/src/components/transaction/TransactionListSkeleton.tsx
+++ b/fe/src/components/transaction/TransactionListSkeleton.tsx
@@ -1,0 +1,55 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface TransactionListSkeletonProps {
+  compact?: boolean;
+  count?: number;
+}
+
+export function TransactionListSkeleton({
+  compact = false,
+  count = 5,
+}: TransactionListSkeletonProps) {
+  const ItemSkeleton = () => (
+    <div className="flex items-center gap-4 rounded-lg border p-4">
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+
+      <Skeleton className="h-5 w-24" />
+    </div>
+  );
+
+  if (compact) {
+    return (
+      <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
+        <div className="w-full max-w-xl space-y-4">
+          {Array.from({ length: count }).map((_, i) => (
+            <ItemSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
+      <div className="w-full max-w-xl space-y-6">
+        <Skeleton className="h-7 w-20" />
+        <div className="flex gap-2">
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-32" />
+        </div>
+
+        <div className="space-y-4">
+          {Array.from({ length: count }).map((_, i) => (
+            <ItemSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -20,6 +20,7 @@ interface TransactionsSubmitFormProps {
   transaction?: ITransaction | null;
   onClose: () => void;
   onSuccess: () => void;
+  defaultDate?: Date;
 }
 
 export default function TransactionSubmitForm({
@@ -27,6 +28,7 @@ export default function TransactionSubmitForm({
   transaction,
   onClose,
   onSuccess,
+  defaultDate,
 }: TransactionsSubmitFormProps) {
   const initialFormData = useMemo(() => {
     if (mode === 'edit' && transaction) {
@@ -43,12 +45,12 @@ export default function TransactionSubmitForm({
         title: '',
         type: '' as '' | 'income' | 'expense',
         amount: '',
-        date: new Date(),
+        date: defaultDate ?? new Date(),
         category_id: '',
         tags: [] as string[],
       };
     }
-  }, [mode, transaction]);
+  }, [mode, transaction, defaultDate]);
 
   const {
     formData,

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -165,7 +165,7 @@ export default function TransactionSubmitForm({
       onSubmit={handleSubmit}
       className="mx-auto flex h-full w-full flex-col space-y-6 p-10 pt-2"
     >
-      <div className="sticky top-0 flex items-center justify-between border-b bg-white pb-4">
+      <div className="sticky top-0 flex items-center justify-between border-b bg-background pb-4">
         <Label className="text-xl">
           {mode === 'create' ? '가계부 작성' : '가계부 수정'}
         </Label>

--- a/fe/src/types/transactions.ts
+++ b/fe/src/types/transactions.ts
@@ -3,7 +3,7 @@ export interface ITransaction {
   title: string;
   user_id: string;
   category_id: string;
-  type: 'income' | 'expense';
+  type: 'income' | 'expense' | '';
   date: string;
   amount: number;
   fixed_rule_id: string | null;


### PR DESCRIPTION
## PR 개요
- Panel과 Calendar를 연동해 Panel 내부에서 가계부 CRUD 기능 연결
- 홈(캘린더)와 가계부 skeleton ui 적용

## 변경 사항

### 1. 캘린더 내부 CRUD
- Panel 내부에서 list - create - edit mode를 state로 관리하여 각각 렌더링
- panel에서 보여줄 list로 filter를 제외한 간소화 버전 제작

### 2. 기타 수정사항
- 홈/가계부 페이지에 skeleton ui적용
- 기존 컴포넌트의 스타일을 그대로 가져와 shad/cd 의 Skeleton ui와 같이 적용

## 리뷰 요청 사항
- 홈(캘린더) 페이지의 패널에서의 가계부 CRUD가 정상 작동하는지
- skeleton ui가 제대로 출력되는지

## 추후 할 일
- [ ] 달력 상단 고정 : 월별 일수에 따른 달력 크기 변동에 대응