### PR TITLE
[fix] 분석 페이지 월 이동 시 미래 고정비 거래 생성 문제 수정

### DIFF
--- a/fe/src/hooks/useAnalysisData.ts
+++ b/fe/src/hooks/useAnalysisData.ts
@@ -61,10 +61,11 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
 
         // 분석 데이터 조회 전에 해당 월의 고정비 거래를 먼저 동기화
         const today = formatLocalDate(new Date());
+        const lastMonthThrough = prevEnd < today ? prevEnd : today;
 
         await Promise.all([
           syncByMonthClient(selectedDate, today), // 현재 달 : 오늘까지 생성
-          syncByMonthClient(lastMonthDate, prevEnd), // 이전 달 : 월말까지 생성
+          syncByMonthClient(lastMonthDate, lastMonthThrough), // 이전 달 : 오늘(or 월말)까지 생성
         ]);
 
         // 지출(expense) 또는 수입(income) 타입이고, 해당 기간 내에 작성된 현재 유저의 기록만 조회

--- a/fe/src/hooks/useAnalysisData.ts
+++ b/fe/src/hooks/useAnalysisData.ts
@@ -1,5 +1,5 @@
 import { CategoryAnalysis, TransactionType } from '@/types/analysis';
-import { formatLocalDate, getMonthRange } from '@/utils/date';
+import { formatLocalDate, getMonthRange, minDate } from '@/utils/date';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ITransaction } from '@/types/transactions';
@@ -61,7 +61,7 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
 
         // 분석 데이터 조회 전에 해당 월의 고정비 거래를 먼저 동기화
         const today = formatLocalDate(new Date());
-        const lastMonthThrough = prevEnd < today ? prevEnd : today;
+        const lastMonthThrough = minDate(prevEnd, today);
 
         await Promise.all([
           syncByMonthClient(selectedDate, today), // 현재 달 : 오늘까지 생성

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -91,6 +91,7 @@ export const syncByMonthShared = async (
     generateThroughDate && generateThroughDate < endDate
       ? generateThroughDate
       : endDate;
+  if (startDate > effectiveEndDate) return { createCount: 0 };
 
   // 해당 월에 유효한 고정비 규칙 조회
   const rules = await deps.fetchFixedRules({

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -91,7 +91,7 @@ export const syncByMonthShared = async (
     generateThroughDate && generateThroughDate < endDate
       ? generateThroughDate
       : endDate;
-  if (startDate > effectiveEndDate) return { createCount: 0 };
+  if (startDate > effectiveEndDate) return { createdCount: 0 };
 
   // 해당 월에 유효한 고정비 규칙 조회
   const rules = await deps.fetchFixedRules({

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -1,5 +1,6 @@
 import type { FixedTransactionInsert, IFixedRule } from '@/types/fixed-costs';
 import { getFixedRuleDates } from './getRuleDates';
+import { minDate } from '@/utils/date';
 
 type SyncDeps = {
   fetchFixedRules: (args: {
@@ -87,10 +88,9 @@ export const syncByMonthShared = async (
   const { userId, monthDate, startDate, endDate, generateThroughDate } = args;
 
   // 생성 범위 상한 : 월말(endDate)과 generateThroughDate 중 더 이른 날짜
-  const effectiveEndDate =
-    generateThroughDate && generateThroughDate < endDate
-      ? generateThroughDate
-      : endDate;
+  const effectiveEndDate = generateThroughDate
+    ? minDate(generateThroughDate, endDate)
+    : endDate;
   if (startDate > effectiveEndDate) return { createdCount: 0 };
 
   // 해당 월에 유효한 고정비 규칙 조회

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -56,3 +56,6 @@ export const parseLocalDate = (value?: string | null): Date | undefined => {
   const [year, month, day] = value.split('-').map(Number);
   return new Date(year, (month ?? 1) - 1, day ?? 1, 0, 0, 0, 0);
 };
+
+// YYYY-MM-DD 형식 문자열 날짜 비교 (사전순 비교 = 날짜 비교)
+export const minDate = (a: string, b: string) => (a < b ? a : b);

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -21,8 +21,8 @@ export const getWeekRange = (date: Date) => {
   const end = endOfWeek(date, { weekStartsOn: 1 });
 
   return {
-    startDate: start.toISOString().slice(0, 10),
-    endDate: end.toISOString().slice(0, 10),
+    startDate: formatLocalDate(start),
+    endDate: formatLocalDate(end),
   };
 };
 


### PR DESCRIPTION
## PR 개요

분석 페이지에서 월 이동 시 선택한 달과 이전 달을 기준으로 고정비 거래를 동기화하는 과정에서,
오늘 기준 미래 월의 고정비 거래가 생성되던 문제를 수정했습니다.

## 변경 사항
### 고정비 동기화 로직 개선
- 분석 페이지 고정비 동기화 시 이전 달도 today 기준 상한 적용
- `syncByMonthShared`에서 생성 상한 계산 로직 개선 및 미래 월 early return 처리

### 날짜 유틸 및 로컬 날짜 기준 정합성 개선
- 날짜 문자열 비교 유틸(`minDate`) 추가로 상한 계산 의도 명확화
- 주 단위 날짜 계산에서 UTC 변환 제거하여 로컬 날짜 기준 유지

## 리뷰 요청 사항
> 원활한 동작 확인을 위해 오늘 이후 날짜로 생성된 모든 거래 내역은 제거해둔 상태입니다.
- 분석 페이지 월 이동 시 미래 월(선택 달 / 이전 달)에 대해
  고정비 거래가 생성되지 않는지 확인 부탁드립니다.

## 추후 할 일

- [ ] 소비 패턴 기반 하루 권장 사용 금액 추천 기능 구현 #59 
