### PR TITLE
[feat] 가변 예산 기준 일일 권장 사용 금액 산출

### DIFF
--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -10,6 +10,11 @@ import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
 import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 import { getTotalBudgetAmount } from '@/utils/budget';
 import { fetchBudgetsServer } from '@/services/budgets/budget';
+import {
+  sumExpenseUntilYesterday,
+  sumFixedExpenseUntilYesterday,
+} from '@/utils/transaction';
+import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
 
 interface PageProps {
   searchParams: Promise<{
@@ -63,9 +68,31 @@ async function DataCalendar({
   budget: number;
 }) {
   const transactions = await getTransaction(filters, true);
-  const amount = 0;
-  const varRemaining = 0;
-  const remainingDays = 0;
+  const today = new Date();
+
+  const spentTotalUntilYesterday = sumExpenseUntilYesterday(
+    transactions,
+    today
+  );
+  const spentFixedUntilYesterday = sumFixedExpenseUntilYesterday(
+    transactions,
+    today
+  );
+
+  const fixedPlannedThisMonth = 0;
+
+  const daily = calculateDailyRec({
+    today,
+    budget,
+    fixedPlannedThisMonth,
+    spentTotalUntilYesterday,
+    spentFixedUntilYesterday,
+  });
+
+  const amount = daily.amount;
+  const varRemaining = daily.debug.varRemaining;
+  const remainingDays = daily.debug.remainingDays;
+
   return (
     <div className="flex w-full flex-col gap-3">
       <DailyRecBar

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -8,6 +8,9 @@ import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
 import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
+import { getTotalBudgetAmount } from '@/utils/budget';
+import { fetchBudgetsServer } from '@/services/budgets/budget';
+
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -27,6 +30,9 @@ export default async function Home({ searchParams }: PageProps) {
     end_date: endDate,
   };
 
+  const budgets = await fetchBudgetsServer(monthDate);
+  const budget = getTotalBudgetAmount(budgets);
+
   return (
     <div className="flex min-h-[900px] w-full max-w-6xl self-start">
       <TransactionProvider>
@@ -36,6 +42,7 @@ export default async function Home({ searchParams }: PageProps) {
               filters={filters}
               currentMonth={currentMonth}
               selectedDate={params.selected_date}
+              budget={budget}
             />
           </Suspense>
         </CalendarProvider>
@@ -48,10 +55,12 @@ async function DataCalendar({
   filters,
   currentMonth,
   selectedDate,
+  budget,
 }: {
   filters: TransactionFilters;
   currentMonth: string;
   selectedDate?: string;
+  budget: number;
 }) {
   const transactions = await getTransaction(filters, true);
   const amount = 0;
@@ -63,6 +72,7 @@ async function DataCalendar({
         amount={amount}
         varRemaining={varRemaining}
         remainingDays={remainingDays}
+        budget={budget}
       />
 
       <Calendar currentMonth={currentMonth} transactions={transactions} />

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -7,6 +7,7 @@ import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
+import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -27,7 +28,7 @@ export default async function Home({ searchParams }: PageProps) {
   };
 
   return (
-    <div className="flex w-full max-w-6xl self-start min-h-[900px]">
+    <div className="flex min-h-[900px] w-full max-w-6xl self-start">
       <TransactionProvider>
         <CalendarProvider>
           <Suspense fallback={<CalendarSkeleton />}>
@@ -53,5 +54,18 @@ async function DataCalendar({
   selectedDate?: string;
 }) {
   const transactions = await getTransaction(filters, true);
-  return <Calendar currentMonth={currentMonth} transactions={transactions} />;
+  const amount = 0;
+  const varRemaining = 0;
+  const remainingDays = 0;
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <DailyRecBar
+        amount={amount}
+        varRemaining={varRemaining}
+        remainingDays={remainingDays}
+      />
+
+      <Calendar currentMonth={currentMonth} transactions={transactions} />
+    </div>
+  );
 }

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -15,6 +15,8 @@ import {
   sumFixedExpenseUntilYesterday,
 } from '@/utils/transaction';
 import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
+import { fetchFixedRulesByMonthServer } from '@/services/fixed-costs/fixedCostsServer';
+import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs';
 
 interface PageProps {
   searchParams: Promise<{
@@ -38,6 +40,12 @@ export default async function Home({ searchParams }: PageProps) {
   const budgets = await fetchBudgetsServer(monthDate);
   const budget = getTotalBudgetAmount(budgets);
 
+  const fixedRules = await fetchFixedRulesByMonthServer(monthDate);
+  const fixedPlannedThisMonth = getFixedPlannedExpenseByMonth(
+    fixedRules,
+    monthDate
+  );
+
   return (
     <div className="flex min-h-[900px] w-full max-w-6xl self-start">
       <TransactionProvider>
@@ -48,6 +56,7 @@ export default async function Home({ searchParams }: PageProps) {
               currentMonth={currentMonth}
               selectedDate={params.selected_date}
               budget={budget}
+              fixedPlannedThisMonth={fixedPlannedThisMonth}
             />
           </Suspense>
         </CalendarProvider>
@@ -61,11 +70,13 @@ async function DataCalendar({
   currentMonth,
   selectedDate,
   budget,
+  fixedPlannedThisMonth,
 }: {
   filters: TransactionFilters;
   currentMonth: string;
   selectedDate?: string;
   budget: number;
+  fixedPlannedThisMonth: number;
 }) {
   const transactions = await getTransaction(filters, true);
   const today = new Date();
@@ -78,8 +89,6 @@ async function DataCalendar({
     transactions,
     today
   );
-
-  const fixedPlannedThisMonth = 0;
 
   const daily = calculateDailyRec({
     today,

--- a/fe/src/components/daily-recommendation/DailyRecBar.tsx
+++ b/fe/src/components/daily-recommendation/DailyRecBar.tsx
@@ -9,9 +9,15 @@ type Props = {
   amount: number; // 일일 권장 사용 금액
   varRemaining: number; // 남은 가변 예산
   remainingDays: number; // 오늘 포함 남은 일수
+  budget: number;
 };
 
-export const DailyRecBar = ({ amount, varRemaining, remainingDays }: Props) => {
+export const DailyRecBar = ({
+  amount,
+  varRemaining,
+  remainingDays,
+  budget,
+}: Props) => {
   return (
     <>
       {/* 안내 바 */}
@@ -27,7 +33,7 @@ export const DailyRecBar = ({ amount, varRemaining, remainingDays }: Props) => {
 
           <div className="text-muted-foreground text-xs">
             남은 사용 가능 금액 {varRemaining.toLocaleString()}원 · 남은{' '}
-            {remainingDays}일
+            {remainingDays}일 · 이번 달 총 예산 {budget.toLocaleString()}원
           </div>
         </div>
 

--- a/fe/src/components/daily-recommendation/DailyRecBar.tsx
+++ b/fe/src/components/daily-recommendation/DailyRecBar.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { ChevronRight } from 'lucide-react';
 import ResponsivePanel from '../panel/ResponsivePanel';
+import { DailyRecPanel } from './DailyRecPanel';
 
 type Props = {
   amount: number; // 일일 권장 사용 금액
@@ -43,7 +44,7 @@ export const DailyRecBar = ({ amount, varRemaining, remainingDays }: Props) => {
             </Button>
           }
         >
-          <div>패널</div>
+          <DailyRecPanel />
         </ResponsivePanel>
       </div>
     </>

--- a/fe/src/components/daily-recommendation/DailyRecBar.tsx
+++ b/fe/src/components/daily-recommendation/DailyRecBar.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { ChevronRight } from 'lucide-react';
+import ResponsivePanel from '../panel/ResponsivePanel';
+
+type Props = {
+  amount: number; // 일일 권장 사용 금액
+  varRemaining: number; // 남은 가변 예산
+  remainingDays: number; // 오늘 포함 남은 일수
+};
+
+export const DailyRecBar = ({ amount, varRemaining, remainingDays }: Props) => {
+  return (
+    <>
+      {/* 안내 바 */}
+      <div className="bg-muted/50 flex items-center justify-between rounded-md px-4 py-3">
+        {/* 왼쪽 정보 영역 */}
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">오늘 권장 사용액</span>
+            <div className="text-xl font-semibold">
+              {amount.toLocaleString()}원
+            </div>
+          </div>
+
+          <div className="text-muted-foreground text-xs">
+            남은 사용 가능 금액 {varRemaining.toLocaleString()}원 · 남은{' '}
+            {remainingDays}일
+          </div>
+        </div>
+
+        {/* 오른쪽 액션 */}
+        <ResponsivePanel
+          trigger={
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex items-center gap-1"
+            >
+              자세히
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          }
+        >
+          <div>패널</div>
+        </ResponsivePanel>
+      </div>
+    </>
+  );
+};

--- a/fe/src/components/daily-recommendation/DailyRecPanel.tsx
+++ b/fe/src/components/daily-recommendation/DailyRecPanel.tsx
@@ -1,0 +1,12 @@
+export const DailyRecPanel = () => {
+  return (
+    <div className="space-y-4 text-sm">
+      <p>
+        오늘 권장 사용액은 이번 달 예산과 어제까지의 소비 내역을 바탕으로
+        계산됩니다.
+      </p>
+      <p>이번 달 총 예산에서 고정비와 이미 사용한 금액을 제외한 금액입니다.</p>
+      <p>자세한 계산 근거</p>
+    </div>
+  );
+};

--- a/fe/src/services/budgets/budget.ts
+++ b/fe/src/services/budgets/budget.ts
@@ -1,0 +1,26 @@
+import { getMonthRange } from '@/utils/date';
+import { createClient } from '@/utils/supabase/server';
+import type { Budget } from '@/types/analysis';
+
+export const fetchBudgetsServer = async (date: Date): Promise<Budget[]> => {
+  const supabase = await createClient();
+  const { data: auth, error: authError } = await supabase.auth.getUser();
+  if (authError || !auth.user) throw new Error('로그인이 필요합니다');
+
+  const { startDate } = getMonthRange(date);
+
+  const { data, error } = await supabase
+    .from('budgets')
+    .select(
+      `*, 
+       categories!category_id (
+         name_ko,
+         category_key
+       )`
+    )
+    .eq('user_id', auth.user.id)
+    .eq('budget_month', startDate);
+
+  if (error) throw error;
+  return (data ?? []) as Budget[];
+};

--- a/fe/src/services/daily-recommendation/calculate.ts
+++ b/fe/src/services/daily-recommendation/calculate.ts
@@ -1,0 +1,68 @@
+import { getMonthDayStats } from '@/utils/date';
+
+// 일일 권장 사용 금액 계산에 필요한 입력 값
+export type DailyRecInput = {
+  today: Date;
+  budget: number;
+  fixedPlannedThisMonth: number; // 이번 달 예정 고정비 합
+  spentTotalUntilYesterday: number; // 이번 달 어제까지의 총 지출 합
+  spentFixedUntilYesterday: number; // 이번 달 어제까지 고정비로 지출된 금액 합
+};
+
+// 디버그용 중간 계산 결과
+export type DailyRecDebug = {
+  // 날짜 관련
+  daysInMonth: number;
+  dayOfMonth: number;
+  elapsedDays: number;
+  remainingDays: number;
+
+  // 가변 예산 흐름
+  varTotal: number;
+  varSpentUntilYesterday: number;
+  varRemaining: number;
+
+  // 계산 단계별 값
+  baseDaily: number;
+};
+
+export type DailyRecResult = {
+  amount: number; // 최종 일일 권장 사용 금액
+  debug: DailyRecDebug;
+};
+
+// 일일 권장 사용 금액 계산
+export const calculateDailyRec = (input: DailyRecInput): DailyRecResult => {
+  // 날짜 통계
+  const { daysInMonth, dayOfMonth, elapsedDays, remainingDays } =
+    getMonthDayStats(input.today);
+
+  // 이번 달 가변 총액
+  const varTotal = input.budget - input.fixedPlannedThisMonth;
+
+  // 어제까지 가변 지출
+  const varSpentUntilYesterday =
+    input.spentTotalUntilYesterday - input.spentFixedUntilYesterday;
+  // 남은 가변 예산
+  const varRemaining = varTotal - varSpentUntilYesterday;
+
+  // 기본 일일 한도
+  const baseDaily = remainingDays > 0 ? varRemaining / remainingDays : 0;
+  const amount = Math.floor(Math.min(baseDaily, varRemaining));
+
+  return {
+    amount,
+    debug: {
+      daysInMonth,
+      dayOfMonth,
+      elapsedDays,
+      remainingDays,
+
+      varTotal,
+      varSpentUntilYesterday,
+      varRemaining,
+
+      baseDaily,
+    },
+  };
+};

--- a/fe/src/services/daily-recommendation/calculate.ts
+++ b/fe/src/services/daily-recommendation/calculate.ts
@@ -31,6 +31,9 @@ export type DailyRecResult = {
   debug: DailyRecDebug;
 };
 
+// 계산 결과를 항상 0 이상인 유한한 숫자로 보정
+const toNonNegative = (n: number) => (Number.isFinite(n) ? Math.max(n, 0) : 0);
+
 // 일일 권장 사용 금액 계산
 export const calculateDailyRec = (input: DailyRecInput): DailyRecResult => {
   // 날짜 통계
@@ -38,17 +41,19 @@ export const calculateDailyRec = (input: DailyRecInput): DailyRecResult => {
     getMonthDayStats(input.today);
 
   // 이번 달 가변 총액
-  const varTotal = input.budget - input.fixedPlannedThisMonth;
+  const varTotal = toNonNegative(input.budget - input.fixedPlannedThisMonth);
 
   // 어제까지 가변 지출
-  const varSpentUntilYesterday =
-    input.spentTotalUntilYesterday - input.spentFixedUntilYesterday;
+  const varSpentUntilYesterday = toNonNegative(
+    input.spentTotalUntilYesterday - input.spentFixedUntilYesterday
+  );
+
   // 남은 가변 예산
-  const varRemaining = varTotal - varSpentUntilYesterday;
+  const varRemaining = toNonNegative(varTotal - varSpentUntilYesterday);
 
   // 기본 일일 한도
   const baseDaily = remainingDays > 0 ? varRemaining / remainingDays : 0;
-  const amount = Math.floor(Math.min(baseDaily, varRemaining));
+  const amount = Math.floor(Math.min(toNonNegative(baseDaily), varRemaining));
 
   return {
     amount,

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -1,0 +1,27 @@
+import { getMonthRange } from '@/utils/date';
+import type { IFixedRule } from '@/types/fixed-costs';
+import { createClient } from '@/utils/supabase/server';
+
+// 해당 월에 적용되는 고정비 규칙 조회 (서버용)
+export const fetchFixedRulesByMonthServer = async (monthDate: Date) => {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (!user || userError) throw new Error('로그인이 필요합니다');
+
+  const { startDate, endDate } = getMonthRange(monthDate);
+
+  const { data, error } = await supabase
+    .from('fixed_rules')
+    .select('*')
+    .eq('user_id', user.id)
+    .lte('start_date', endDate)
+    .or(`end_date.is.null,end_date.gte.${startDate}`);
+
+  if (error) throw error;
+  return (data ?? []) as IFixedRule[];
+};

--- a/fe/src/utils/budget.ts
+++ b/fe/src/utils/budget.ts
@@ -1,0 +1,7 @@
+import type { Budget } from '@/types/analysis';
+
+// 특정 월 총 예산 금액 반환
+export const getTotalBudgetAmount = (budgets: Budget[]) => {
+  const total = budgets.find((b) => b.category_id === null);
+  return total?.amount ?? 0;
+};

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -59,3 +59,22 @@ export const parseLocalDate = (value?: string | null): Date | undefined => {
 
 // YYYY-MM-DD 형식 문자열 날짜 비교 (사전순 비교 = 날짜 비교)
 export const minDate = (a: string, b: string) => (a < b ? a : b);
+
+// 월 기준 일자 통계
+export type MonthDayStats = {
+  daysInMonth: number; // 이번 달 총 일수
+  dayOfMonth: number; // 오늘이 이번 달의 몇 번째 날인지
+  elapsedDays: number; // 어제까지 경과한 일수
+  remainingDays: number; // 오늘 포함 남은 일수
+};
+
+export const getMonthDayStats = (today: Date): MonthDayStats => {
+  const year = today.getFullYear();
+  const monthIndex = today.getMonth();
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const dayOfMonth = today.getDate(); // (1~말일)
+  const elapsedDays = Math.max(dayOfMonth - 1, 0);
+  const remainingDays = Math.max(daysInMonth - dayOfMonth + 1, 1);
+
+  return { daysInMonth, dayOfMonth, elapsedDays, remainingDays };
+};

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -78,3 +78,10 @@ export const getMonthDayStats = (today: Date): MonthDayStats => {
 
   return { daysInMonth, dayOfMonth, elapsedDays, remainingDays };
 };
+
+// 로컬 기준 어제 날짜를 'YYYY-MM-DD' 문자열로 반환
+export const getYesterdayLocalDate = (today: Date) => {
+  const d = new Date(today);
+  d.setDate(d.getDate() - 1);
+  return formatLocalDate(d);
+};

--- a/fe/src/utils/fixed-costs.ts
+++ b/fe/src/utils/fixed-costs.ts
@@ -9,6 +9,7 @@ import {
   addMonths,
   addWeeks,
 } from 'date-fns';
+import { getFixedRuleDates } from '@/services/fixed-costs/getRuleDates';
 
 const WEEKDAY_LABEL: Record<number, string> = {
   1: '월',
@@ -94,4 +95,17 @@ export const getRuleApplyRange = ({
     from: startOfWeek(today, { weekStartsOn: 1 }),
     to: endOfWeek(today, { weekStartsOn: 1 }),
   };
+};
+
+// 이번 달에 예정된 고정비 지출 총합 계산
+export const getFixedPlannedExpenseByMonth = (
+  rules: IFixedRule[],
+  monthDate: Date
+) => {
+  return rules
+    .filter((r) => r.type === 'expense')
+    .reduce((sum, r) => {
+      const occurrences = getFixedRuleDates(r, monthDate).length;
+      return sum + r.amount * occurrences;
+    }, 0);
 };

--- a/fe/src/utils/transaction.ts
+++ b/fe/src/utils/transaction.ts
@@ -1,0 +1,38 @@
+import { ITransaction } from '@/types/transactions';
+
+export const isExpense = (
+  t: ITransaction
+): t is ITransaction & { type: 'expense' } => t.type === 'expense';
+
+export const isFixedExpense = (t: ITransaction) =>
+  isExpense(t) && Boolean(t.fixed_rule_id);
+
+// YYYY-MM-DD 형식 문자열 날짜 비교
+export const isOnOrBefore = (a: string, b: string) => a <= b;
+
+// 조건에 맞는 거래 합계
+export const sumTransactionAmount = (
+  transactions: ITransaction[],
+  predicate?: (t: ITransaction) => boolean
+) =>
+  transactions.reduce((acc, t) => {
+    if (predicate && !predicate(t)) return acc;
+    return acc + (Number.isFinite(t.amount) ? t.amount : 0);
+  }, 0);
+
+// 특정 기준일(until)까지의 총 지출 합계
+export const sumExpenseUntil = (transactions: ITransaction[], until: string) =>
+  sumTransactionAmount(
+    transactions,
+    (t) => isExpense(t) && isOnOrBefore(t.date, until)
+  );
+
+// 특정 기준일(until)까지의 고정비 지출 합계
+export const sumFixedExpenseUntil = (
+  transactions: ITransaction[],
+  until: string
+) =>
+  sumTransactionAmount(
+    transactions,
+    (t) => isFixedExpense(t) && isOnOrBefore(t.date, until)
+  );

--- a/fe/src/utils/transaction.ts
+++ b/fe/src/utils/transaction.ts
@@ -1,4 +1,5 @@
 import { ITransaction } from '@/types/transactions';
+import { getYesterdayLocalDate } from './date';
 
 export const isExpense = (
   t: ITransaction
@@ -27,6 +28,12 @@ export const sumExpenseUntil = (transactions: ITransaction[], until: string) =>
     (t) => isExpense(t) && isOnOrBefore(t.date, until)
   );
 
+// 어제까지의 총 지출 합계
+export const sumExpenseUntilYesterday = (
+  transactions: ITransaction[],
+  today: Date
+) => sumExpenseUntil(transactions, getYesterdayLocalDate(today));
+
 // 특정 기준일(until)까지의 고정비 지출 합계
 export const sumFixedExpenseUntil = (
   transactions: ITransaction[],
@@ -36,3 +43,9 @@ export const sumFixedExpenseUntil = (
     transactions,
     (t) => isFixedExpense(t) && isOnOrBefore(t.date, until)
   );
+
+// 어제까지의 고정비 지출 합계
+export const sumFixedExpenseUntilYesterday = (
+  transactions: ITransaction[],
+  today: Date
+) => sumFixedExpenseUntil(transactions, getYesterdayLocalDate(today));


### PR DESCRIPTION
## PR 개요

- 총 예산에서 고정비를 제외한 가변 예산을 기준으로  남은 기간 동안 사용할 수 있는 **기본 일일 권장 사용 금액 산출 로직**을 구현했습니다.
- 본 PR에서는 누적 소비 흐름에 따른 보정은 제외하고,  **남은 가변 예산 ÷ 남은 일수** 기반의 기본 계산까지를 범위로 합니다.

## 변경 사항
### 1. 가변 예산 기준 기본 일일 권장 사용 금액 계산 로직 구현
#### 1-1. 이번 달 총 예산 조회 및 금액 추출
- 기존 분석 페이지에서 사용 중인 **클라이언트 전용 예산 조회 로직**과 분리하여,
    홈(Server Component)에서 사용할 수 있도록 **서버 전용 예산 조회 로직** 추가
- 서버용 Supabase client를 사용하는 `fetchBudgetsServer` 구현

#### 1-2. 고정비 규칙 기반 이번 달 예정 고정비 합 계산
- 홈(Server Component)에서 사용하기 위한 **서버 전용 고정비 규칙 조회 로직** 추가
- 서버용 Supabase client를 사용하는 `fetchFixedRulesByMonthServer` 구현
- 각 고정비 규칙에 대해
    - MONTHLY / WEEKLY cycle에 따라 해당 월의 발생 날짜 계산
    - 지출(`expense`) 타입 고정비만 대상으로 합산

#### 1-3. 어제까지의 가변 지출 합 계산
- 거래 내역을 기반으로 **어제까지 발생한 지출 중 고정비를 제외한 가변 지출 합**을 계산
- 거래 합계 계산을 위한 유틸(`utils/transaction.ts`)을 추가하여
    - 지출/고정비 여부 판단(`isExpense/isFixedExpense`)
    - 날짜 기준 필터링(`isOnOrBefore`)
    - 특정 기준일까지의 합계 계산 로직을 분리(`sumTransactionAmount`)

#### 1-4. 남은 가변 예산 및 기본 일일 권장 사용 금액 산출
- `총 예산 - 예정 고정비 합`을 통해 **이번 달 가변 예산 총액** 계산
- `가변 예산 - 어제까지의 가변 지출`을 통해 **남은 가변 예산** 계산
- `남은 가변 예산 ÷ 남은 일수` 기준으로 **기본 일일 권장 사용 금액** 산출

## 2. 홈 캘린더 상단 안내 바에 계산 결과 연결
#### 2-1. 홈에서 계산에 필요한 데이터 조합
- 홈 페이지에서 이번 달 총 예산, 이번 달 예정 고정비 합 조회
- 계산에 필요한 숫자 값만 `DataCalendar` 컴포넌트로 전달

#### 2-2. 일일 권장 사용 금액 UI 연결
- 계산된 **일일 권장 사용 금액**, **남은 가변 예산**, **남은 일수**를 홈 캘린더 상단 안내 바(`DailyRecBar`)에 연결
- 사용자가 오늘 사용할 수 있는 권장 금액과 전체 가변 예산 흐름을 한눈에 파악할 수 있도록 구성

## 리뷰 요청 사항
- 기본 일일 권장 사용 금액 계산 로직이 의도대로 동작하는지 확인 부탁드립니다.
  - 분석 페이지에 설정된 총 예산 금액과 안내 바의 총 예산이 동일하게 반영되는지
  - 총 예산에서 이번 달 예정 고정비를 제외한 금액이 남은 사용 가능 금액으로 계산되는지
  - 남은 사용 가능 금액을 남은 일수로 나눈 값이 오늘의 권장 사용액으로 표시되는지

## 추후 할 일
- [ ] 계획 대비 누적 소비 흐름을 반영한 일일 권장 금액 보정 로직 추가 #62 