### PR TITLE
[feat] OCR을 이용한 가계부 지출 입력 자동화

### DIFF
--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -7,21 +7,36 @@ import ResponsivePanel from '@/components/panel/ResponsivePanel';
 import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
 import OCR from '@/components/transaction/OCR';
+import { useState } from 'react';
+
+export interface OCRResult {
+  title: string;
+  date: string;
+  category_id: string;
+  amount: number;
+}
 
 export default function TransactionClient() {
   const router = useRouter();
   const { selectedTransaction, isOpen, openCreate, close } = useSelected();
+  const [ocrData, setOcrData] = useState<OCRResult | null>(null);
 
   const handleSuccess = () => {
     close();
+    setOcrData(null);
     router.refresh();
+  };
+
+  const handleOCRResult = (data: OCRResult) => {
+    setOcrData(data);
+    openCreate();
   };
 
   const mode = selectedTransaction ? 'edit' : 'create';
 
   return (
     <>
-      <OCR />
+      <OCR onResult={handleOCRResult} />
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"
@@ -35,6 +50,7 @@ export default function TransactionClient() {
           transaction={selectedTransaction}
           onClose={close}
           onSuccess={handleSuccess}
+          defaultValue={ocrData}
         />
       </ResponsivePanel>
     </>

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -6,6 +6,7 @@ import { Plus } from 'lucide-react';
 import ResponsivePanel from '@/components/panel/ResponsivePanel';
 import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
+import TestOCR from '@/components/transaction/TestOCR';
 
 export default function TransactionClient() {
   const router = useRouter();
@@ -20,6 +21,7 @@ export default function TransactionClient() {
 
   return (
     <>
+      <TestOCR />
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -27,6 +27,10 @@ export default function TransactionClient() {
     router.refresh();
   };
 
+  const handleClose = () => {
+    close();
+    setOcrData(null);
+  };
   const handleOCRResult = (data: OCRResult) => {
     setOcrData(data);
     openCreate();
@@ -44,11 +48,11 @@ export default function TransactionClient() {
       >
         <Plus size={20} />
       </Button>
-      <ResponsivePanel isOpen={isOpen} setIsOpen={close}>
+      <ResponsivePanel isOpen={isOpen} setIsOpen={handleSuccess}>
         <TransactionSubmitForm
           mode={mode}
           transaction={selectedTransaction}
-          onClose={close}
+          onClose={handleClose}
           onSuccess={handleSuccess}
           defaultValue={ocrData}
         />

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -6,7 +6,7 @@ import { Plus } from 'lucide-react';
 import ResponsivePanel from '@/components/panel/ResponsivePanel';
 import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
-import TestOCR from '@/components/transaction/TestOCR';
+import OCR from '@/components/transaction/OCR';
 
 export default function TransactionClient() {
   const router = useRouter();
@@ -21,7 +21,7 @@ export default function TransactionClient() {
 
   return (
     <>
-      <TestOCR />
+      <OCR />
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -8,13 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
 import OCR from '@/components/transaction/OCR';
 import { useState } from 'react';
-
-export interface OCRResult {
-  title: string;
-  date: Date;
-  category_id: string;
-  amount: number;
-}
+import { OCRResult } from '@/types/transactions';
 
 export default function TransactionClient() {
   const router = useRouter();

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 
 export interface OCRResult {
   title: string;
-  date: string;
+  date: Date;
   category_id: string;
   amount: number;
 }

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -7,7 +7,7 @@ import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
-import TestOCR from '@/components/transaction/TestOCR';
+import TestOCR from '@/components/transaction/OCR';
 interface PageProps {
   searchParams: Promise<{
     month?: string;

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -7,6 +7,7 @@ import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
+import TestOCR from '@/components/transaction/TestOCR';
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -27,7 +28,7 @@ export default async function Home({ searchParams }: PageProps) {
   };
 
   return (
-    <div className="flex w-full max-w-6xl self-start min-h-[900px]">
+    <div className="flex min-h-[900px] w-full max-w-6xl self-start">
       <TransactionProvider>
         <CalendarProvider>
           <Suspense fallback={<CalendarSkeleton />}>
@@ -39,6 +40,7 @@ export default async function Home({ searchParams }: PageProps) {
           </Suspense>
         </CalendarProvider>
       </TransactionProvider>
+      <TestOCR />
     </div>
   );
 }

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -7,7 +7,6 @@ import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
-import TestOCR from '@/components/transaction/OCR';
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -40,7 +39,6 @@ export default async function Home({ searchParams }: PageProps) {
           </Suspense>
         </CalendarProvider>
       </TransactionProvider>
-      <TestOCR />
     </div>
   );
 }

--- a/fe/src/app/api/ocr/route.ts
+++ b/fe/src/app/api/ocr/route.ts
@@ -1,0 +1,18 @@
+export const POST =async(request)=>{
+      const {image} = await request.json();
+
+      const response = await fetch('', {
+      headers: {
+            'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`, // 서버에만 존재
+      },
+      body: JSON.stringify({
+                  model: 'gpt-4o-mini',
+                  messages: [{
+                  role: 'user',
+                  content: []
+                  }]
+            })
+      });
+      
+      return Response.json(await response.json());
+}

--- a/fe/src/app/api/ocr/route.ts
+++ b/fe/src/app/api/ocr/route.ts
@@ -13,8 +13,13 @@ const promptText = `
 2. 품목의 모든 결제 금액을 더해 총액을 계산
 3. 모든 품목의 금액 총합과 총 결제 금액으로 명시된 금액을 비교하여 판단
 4. 아래 JSON 형식으로 결과를 출력
-
+5. 영수증이 아니라고 인식되었을 경우 에러처리
 JSON 형식:
+영수증이 아닌 경우 :
+{
+  "error" : "영수증이 아닙니다"
+}
+영수증인 경우 :
 {
   "title": "가게명/거래처 명",
   "date": "YYYY-MM-DD",
@@ -56,7 +61,18 @@ export const POST = async (request: Request) => {
     }
     const content = data.choices[0].message.content;
 
+    if (!content) {
+      return Response.json(
+        { error: '응답을 받지 못했습니다' },
+        { status: 500 }
+      );
+    }
+
     const cleaned = content.replace(/```json\n?|\n?```/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    if (parsed.error) {
+      return Response.json({ error: parsed.error }, { status: 400 });
+    }
     return Response.json(JSON.parse(cleaned));
   } catch (error) {
     return Response.json(

--- a/fe/src/app/api/ocr/route.ts
+++ b/fe/src/app/api/ocr/route.ts
@@ -1,18 +1,67 @@
-export const POST =async(request)=>{
-      const {image} = await request.json();
+import { CATEGORIES } from '@/constants/categories';
 
-      const response = await fetch('', {
+const expenseCATEGORIES = CATEGORIES.expense
+  .map((cat) => `"${cat.category_key}"`)
+  .join('|');
+
+const promptText = `
+한국의 영수증 OCR 분석
+이 영수증 이미지를 정확하게 분석해줘
+
+규칙:
+1. 금액은 숫자만 추출
+2. 품목의 모든 결제 금액을 더해 총액을 계산
+3. 모든 품목의 금액 총합과 총 결제 금액으로 명시된 금액을 비교하여 판단
+4. 아래 JSON 형식으로 결과를 출력
+
+JSON 형식:
+{
+  "title": "가게명/거래처 명",
+  "date": "YYYY-MM-DD",
+  "category_id": ${expenseCATEGORIES} 중 하나,
+  "amount" 결제금액
+}
+다른 대답 없이 JSON 형식으로만 추출할 것  
+`;
+export const POST = async (request: Request) => {
+  try {
+    const { image } = await request.json();
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
       headers: {
-            'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`, // 서버에만 존재
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-                  model: 'gpt-4o-mini',
-                  messages: [{
-                  role: 'user',
-                  content: []
-                  }]
-            })
-      });
-      
-      return Response.json(await response.json());
-}
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: promptText,
+              },
+              { type: 'image_url', image_url: { url: image } },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return Response.json({ error: data }, { status: response.status });
+    }
+    const content = data.choices[0].message.content;
+
+    const cleaned = content.replace(/```json\n?|\n?```/g, '').trim();
+    return Response.json(JSON.parse(cleaned));
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+};

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -3,7 +3,13 @@ import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
-export default function OCR() {
+import { OCRResult } from '@/app/(app)/history/TransactionClient';
+
+interface OCRProps {
+  onResult: (data: OCRResult) => void;
+}
+
+export default function OCR({ onResult }: OCRProps) {
   const [result, setResult] = useState(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
@@ -19,7 +25,9 @@ export default function OCR() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ image: reader.result }),
       });
-      setResult(await res.json());
+      const data = await res.json();
+      onResult(data);
+      setResult(data);
       setLoading(false);
     };
 

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -2,11 +2,11 @@
 import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
-export default function TestOCR() {
+export default function OCR() {
   const [result, setResult] = useState(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleTest = async (e) => {
+  const handleUpload = async (e) => {
     const file = e.target.files[0];
     const reader = new FileReader();
 
@@ -36,7 +36,7 @@ export default function TestOCR() {
         type="file"
         accept="image/*"
         capture="environment"
-        onChange={handleTest}
+        onChange={handleUpload}
         hidden
       />
       <div>{JSON.stringify(result)}</div>

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -4,32 +4,43 @@ import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
-
+import { toast } from 'sonner';
 interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
 
 export default function OCR({ onResult }: OCRProps) {
-  const [result, setResult] = useState(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
 
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     const reader = new FileReader();
 
     setLoading(true);
     reader.onloadend = async () => {
-      const res = await fetch('/api/ocr', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image: reader.result }),
-      });
-      const data = await res.json();
-      onResult(data);
-      setResult(data);
-      setLoading(false);
+      try {
+        const res = await fetch('/api/ocr', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: reader.result }),
+        });
+        if (!res.ok) {
+          throw new Error('OCR Request Failed');
+        }
+        const data = await res.json();
+        toast(`영수증 인식이 완료 되었습니다`);
+        onResult(data);
+      } catch (error) {
+        toast(`${error} : 영수증 인식에 실패했습니다`);
+      } finally {
+        setLoading(false);
+        if (inputRef.current) {
+          inputRef.current.value = '';
+        }
+      }
     };
 
     reader.readAsDataURL(file);
@@ -52,7 +63,6 @@ export default function OCR({ onResult }: OCRProps) {
         onChange={handleUpload}
         hidden
       />
-      <div>{JSON.stringify(result)}</div>
     </div>
   );
 }

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -2,14 +2,17 @@
 import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
+import { Spinner } from '../ui/spinner';
 export default function OCR() {
   const [result, setResult] = useState(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleUpload = async (e) => {
     const file = e.target.files[0];
     const reader = new FileReader();
 
+    setLoading(true);
     reader.onloadend = async () => {
       const res = await fetch('/api/ocr', {
         method: 'POST',
@@ -17,6 +20,7 @@ export default function OCR() {
         body: JSON.stringify({ image: reader.result }),
       });
       setResult(await res.json());
+      setLoading(false);
     };
 
     reader.readAsDataURL(file);
@@ -29,7 +33,7 @@ export default function OCR() {
         className="fixed bottom-0 z-50 m-4 h-16 w-16 cursor-pointer rounded-full"
         asChild
       >
-        <Receipt size={20} />
+        {loading ? <Spinner /> : <Receipt size={20} />}
       </Button>
       <input
         ref={inputRef}

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -3,7 +3,7 @@ import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
-import { OCRResult } from '@/app/(app)/history/TransactionClient';
+import { OCRResult } from '@/types/transactions';
 
 interface OCRProps {
   onResult: (data: OCRResult) => void;
@@ -14,8 +14,8 @@ export default function OCR({ onResult }: OCRProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleUpload = async (e) => {
-    const file = e.target.files[0];
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
     if (!file) return;
     const reader = new FileReader();
 

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -34,7 +34,9 @@ export default function OCR({ onResult }: OCRProps) {
         toast(`영수증 인식이 완료 되었습니다`);
         onResult(data);
       } catch (error) {
-        toast(`${error} : 영수증 인식에 실패했습니다`);
+        toast(
+          error instanceof Error ? error.message : '영수증 인식에 실패했습니다'
+        );
       } finally {
         setLoading(false);
         if (inputRef.current) {

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -16,6 +16,7 @@ export default function OCR({ onResult }: OCRProps) {
 
   const handleUpload = async (e) => {
     const file = e.target.files[0];
+    if (!file) return;
     const reader = new FileReader();
 
     setLoading(true);

--- a/fe/src/components/transaction/TestOCR.tsx
+++ b/fe/src/components/transaction/TestOCR.tsx
@@ -1,8 +1,10 @@
 'use client';
-import { useState } from 'react';
-
+import { useState, useRef } from 'react';
+import { Button } from '../ui/button';
+import { Receipt } from 'lucide-react';
 export default function TestOCR() {
   const [result, setResult] = useState(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleTest = async (e) => {
     const file = e.target.files[0];
@@ -22,7 +24,21 @@ export default function TestOCR() {
 
   return (
     <div>
-      <input type="file" accept="image/*" onChange={handleTest} />
+      <Button
+        onClick={() => inputRef.current?.click()}
+        className="fixed bottom-0 z-50 m-4 h-16 w-16 cursor-pointer rounded-full"
+        asChild
+      >
+        <Receipt size={20} />
+      </Button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleTest}
+        hidden
+      />
       <div>{JSON.stringify(result)}</div>
     </div>
   );

--- a/fe/src/components/transaction/TestOCR.tsx
+++ b/fe/src/components/transaction/TestOCR.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useState } from 'react';
+
+export default function TestOCR() {
+  const [result, setResult] = useState(null);
+
+  const handleTest = async (e) => {
+    const file = e.target.files[0];
+    const reader = new FileReader();
+
+    reader.onloadend = async () => {
+      const res = await fetch('/api/ocr', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image: reader.result }),
+      });
+      setResult(await res.json());
+    };
+
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div>
+      <input type="file" accept="image/*" onChange={handleTest} />
+      <div>{JSON.stringify(result)}</div>
+    </div>
+  );
+}

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Button } from '../ui/button';
 import { supabase } from '@/utils/supabase/client';
@@ -76,6 +76,19 @@ export default function TransactionSubmitForm({
     removeTag,
     UpdateField,
   } = useTransactionForm(initialFormData);
+
+  useEffect(() => {
+    if (defaultValue) {
+      setFormData({
+        title: defaultValue.title,
+        type: 'expense',
+        amount: defaultValue.amount.toString(),
+        date: new Date(defaultValue.date),
+        category_id: defaultValue.category_id,
+        tags: [],
+      });
+    }
+  }, [defaultValue, setFormData]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -47,16 +47,16 @@ export default function TransactionSubmitForm({
       if (defaultValue) {
         return {
           title: defaultValue.title,
-          type: 'expense',
+          type: 'expense' as const,
           amount: defaultValue.amount.toString(),
-          date: defaultDate ?? new Date(),
+          date: new Date(defaultValue.date),
           category_id: defaultValue.category_id,
           tags: [] as string[],
         };
       } else {
         return {
           title: '',
-          type: '' as '' | 'income' | 'expense',
+          type: '' as const,
           amount: '',
           date: defaultDate ?? new Date(),
           category_id: '',

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -6,15 +6,13 @@ import { supabase } from '@/utils/supabase/client';
 import { toast } from 'sonner';
 import { Trash } from 'lucide-react';
 import { useTransactionForm } from '@/hooks/useTransactionForm';
-import { ITransaction } from '@/types/transactions';
-
+import { ITransaction, OCRResult } from '@/types/transactions';
 import { AmountInput } from './common/AmountInput';
 import { DatePicker } from './common/DatePicker';
 import { TagInput } from './common/TagInput';
 import { TitleInput } from './common/TitleInput';
 import { TypeSelector } from './common/TypeSelector';
 import { CategorySelector } from './common/CategorySelector';
-import { OCRResult } from '@/app/(app)/history/TransactionClient';
 
 interface TransactionsSubmitFormProps {
   mode: 'create' | 'edit';

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -14,12 +14,14 @@ import { TagInput } from './common/TagInput';
 import { TitleInput } from './common/TitleInput';
 import { TypeSelector } from './common/TypeSelector';
 import { CategorySelector } from './common/CategorySelector';
+import { OCRResult } from '@/app/(app)/history/TransactionClient';
 
 interface TransactionsSubmitFormProps {
   mode: 'create' | 'edit';
   transaction?: ITransaction | null;
   onClose: () => void;
   onSuccess: () => void;
+  defaultValue?: OCRResult | null;
   defaultDate?: Date;
 }
 
@@ -29,6 +31,7 @@ export default function TransactionSubmitForm({
   onClose,
   onSuccess,
   defaultDate,
+  defaultValue,
 }: TransactionsSubmitFormProps) {
   const initialFormData = useMemo(() => {
     if (mode === 'edit' && transaction) {
@@ -41,16 +44,27 @@ export default function TransactionSubmitForm({
         tags: transaction.tags || [],
       };
     } else {
-      return {
-        title: '',
-        type: '' as '' | 'income' | 'expense',
-        amount: '',
-        date: defaultDate ?? new Date(),
-        category_id: '',
-        tags: [] as string[],
-      };
+      if (defaultValue) {
+        return {
+          title: defaultValue.title,
+          type: 'expense',
+          amount: defaultValue.amount.toString(),
+          date: defaultDate ?? new Date(),
+          category_id: defaultValue.category_id,
+          tags: [] as string[],
+        };
+      } else {
+        return {
+          title: '',
+          type: '' as '' | 'income' | 'expense',
+          amount: '',
+          date: defaultDate ?? new Date(),
+          category_id: '',
+          tags: [] as string[],
+        };
+      }
     }
-  }, [mode, transaction, defaultDate]);
+  }, [mode, transaction, defaultDate, defaultValue]);
 
   const {
     formData,
@@ -165,7 +179,7 @@ export default function TransactionSubmitForm({
       onSubmit={handleSubmit}
       className="mx-auto flex h-full w-full flex-col space-y-6 p-10 pt-2"
     >
-      <div className="sticky top-0 flex items-center justify-between border-b bg-background pb-4">
+      <div className="bg-background sticky top-0 flex items-center justify-between border-b pb-4">
         <Label className="text-xl">
           {mode === 'create' ? '가계부 작성' : '가계부 수정'}
         </Label>

--- a/fe/src/types/transactions.ts
+++ b/fe/src/types/transactions.ts
@@ -12,3 +12,10 @@ export interface ITransaction {
   updated_at: Date;
   tags: string[];
 }
+
+export interface OCRResult {
+  title: string;
+  date: Date;
+  category_id: string;
+  amount: number;
+}


### PR DESCRIPTION
## PR 개요
영수증 이미지를 업로드시 OCR을 통해 자동으로 가계부를 생성하는 기능 구현

## 주요 기능

### 1. 영수증 OCR 인식
- Open AI GPT-4o-mini model 사용
- 거래처, 날짜, 총 결제액, 카테고리를 자동 추출
- 영수증이 아닌 이미지에 대한 예외처리

#### Flow
1. 클라이언트에서 이미지를 base64로 변환
2. `api/ocr` 엔드포인트로 전송
3. openAI API로 영수증 분석
4. JSON 형식으로 결과 반환
5. 반환 데이터를 가계부 생성 폼에 default Value로 입력
 
### 2. 가계부 입력 자동화
- OCR 결과를 가계부 입력 폼에 자동 연동
- 영수증 업로드 버튼을 좌측 하단에 배치
- 로딩 상태 처리(+파일 미선택 시 로딩처리)
- 
### 3. 기타 UX 개선 사항
- OCR 결과 성공/실패 여부를 Toast알림으로 안내
- 패널을 닫을 때 데이터 초기화

## 리뷰 전 요청사항
- [ ]  소중한 API KEY가 외부로 유출되지 않도록 해주세요 

## 리뷰 요청사항
- 가계부 리스트 좌측 하단에 영수증 아이콘 버튼이 제대로 보이는지
- 영수증 이미지 선택 시 아이콘 버튼의 로딩 상태가 spinner를 통해 표시되는 지
- 텍스트 검출 성공 후 toast 메세지와 함께 입력폼에 제대로 데이터가 기입되는지
- 영수증이 아닌 이미지를 업로드 할 경우 toast 메세지와 함께 에러 처리가 되는지