### PR TITLE
[fix] 게스트 로그인 시 거래 동기화 로직으로 인한 RLS 오류 방지

### DIFF
--- a/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
@@ -7,7 +7,8 @@ import { PG_ERROR } from '@/constants/postgres';
 // 클라이언트 환경에서 고정비 규칙 기반 월별 거래 동기화
 export const syncByMonthClient = async (
   monthDate: Date,
-  generateThroughDate?: string
+  generateThroughDate?: string,
+  options?: { isGuest?: boolean }
 ) => {
   const userId = await requireUserId();
   const { startDate, endDate } = getMonthRange(monthDate);
@@ -53,6 +54,13 @@ export const syncByMonthClient = async (
         throw error;
       },
     },
-    { userId, monthDate, startDate, endDate, generateThroughDate }
+    {
+      userId,
+      isGuest: options?.isGuest,
+      monthDate,
+      startDate,
+      endDate,
+      generateThroughDate,
+    }
   );
 };

--- a/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
@@ -22,6 +22,14 @@ export const syncByMonthServer = async ({
 
   if (!user) throw new Error('User not authenticated');
 
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_guest')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const isGuest = !!profile?.is_guest;
+
   return syncByMonthShared(
     {
       // 해당 월에 유효한 고정비 규칙 조회
@@ -63,6 +71,13 @@ export const syncByMonthServer = async ({
         throw error;
       },
     },
-    { userId: user.id, monthDate, startDate, endDate, generateThroughDate }
+    {
+      userId: user.id,
+      isGuest,
+      monthDate,
+      startDate,
+      endDate,
+      generateThroughDate,
+    }
   );
 };

--- a/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.shared.ts
@@ -79,13 +79,23 @@ export const syncByMonthShared = async (
   deps: SyncDeps,
   args: {
     userId: string;
+    isGuest?: boolean;
     monthDate: Date;
     startDate: string;
     endDate: string;
     generateThroughDate?: string;
   }
 ) => {
-  const { userId, monthDate, startDate, endDate, generateThroughDate } = args;
+  const {
+    userId,
+    isGuest,
+    monthDate,
+    startDate,
+    endDate,
+    generateThroughDate,
+  } = args;
+
+  if (isGuest) return { createdCount: 0 };
 
   // 생성 범위 상한 : 월말(endDate)과 generateThroughDate 중 더 이른 날짜
   const effectiveEndDate = generateThroughDate


### PR DESCRIPTION
## PR 개요
- 게스트 로그인 상태에서 거래 조회 시 고정비 거래 동기화 로직이 실행되며 `transactions INSERT`가 시도되어 RLS 에러가 발생하던 문제를 수정했습니다.
- 게스트 모드에서는 동기화 로직이 쓰기 작업으로 내려가지 않도록 공통(shared) 레벨에서 차단합니다.

## 변경 사항

- `syncByMonthShared`에 게스트 모드 가드 추가
  - 게스트일 경우 `{ createdCount: 0 }` 반환하여 insert 로직 미실행
- 서버 동기화(`syncByMonthServer`)
  - `profiles.is_guest` 조회 후 `isGuest`를 shared로 전달하도록 개선
- 클라이언트 동기화(`syncByMonthClient`)
  - `isGuest`를 shared로 전달할 수 있도록 개선(호출부에서 게스트 플래그 전달)

## 리뷰 요청 사항
- 게스트 로그인 후 홈 페이지 진입 시 `transactions` 관련 RLS 에러(42501)가 재현되지 않는지 확인 부탁드립니다.