### PR TITLE
[feat] 다중 파일 대한 가계부 지출 입력 자동화

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -6,7 +6,7 @@ import { Plus } from 'lucide-react';
 import ResponsivePanel from '@/components/panel/ResponsivePanel';
 import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
-import OCR from '@/components/transaction/OCR';
+import ReceiptCapture from '@/components/transaction/ReceiptCapture';
 import { useState } from 'react';
 import { OCRResult } from '@/types/transactions';
 
@@ -34,7 +34,7 @@ export default function TransactionClient() {
 
   return (
     <>
-      <OCR onResult={handleOCRResult} />
+      <ReceiptCapture onResult={handleOCRResult} />
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -34,7 +34,6 @@ export default function TransactionClient() {
 
   return (
     <>
-      <ReceiptCapture onResult={handleOCRResult} />
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -9,6 +9,9 @@ import { useSelected } from './TransactionContext';
 import ReceiptCapture from '@/components/transaction/ReceiptCapture';
 import { useState } from 'react';
 import { OCRResult } from '@/types/transactions';
+import ReceiptMulti from '@/components/transaction/ReceiptMulti';
+import { Receipt } from 'lucide-react';
+import { X } from 'lucide-react';
 
 export default function TransactionClient() {
   const router = useRouter();
@@ -34,6 +37,10 @@ export default function TransactionClient() {
 
   return (
     <>
+      <div className="fixed bottom-0 z-50 m-4 flex gap-4 rounded-full bg-[#151515] p-1">
+        <ReceiptCapture onResult={handleOCRResult} />
+        <ReceiptMulti onResult={handleOCRResult} />
+      </div>
       <Button
         onClick={openCreate}
         className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -39,7 +39,7 @@ export default function TransactionClient() {
     <>
       <div className="fixed bottom-0 z-50 m-4 flex gap-4 rounded-full bg-[#151515] p-1">
         <ReceiptCapture onResult={handleOCRResult} />
-        <ReceiptMulti onResult={handleOCRResult} />
+        <ReceiptMulti />
       </div>
       <Button
         onClick={openCreate}

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -7,7 +7,7 @@ import { getMonthRange } from '@/utils/date';
 import { CalendarProvider } from '@/context/CalendarContext';
 import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
-import TestOCR from '@/components/transaction/OCR';
+import TestOCR from '@/components/transaction/ReceiptCapture';
 import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 import { getTotalBudgetAmount } from '@/utils/budget';
 import { fetchBudgetsServer } from '@/services/budgets/budget';

--- a/fe/src/components/transaction/OCR.tsx
+++ b/fe/src/components/transaction/OCR.tsx
@@ -28,7 +28,7 @@ export default function OCR({ onResult }: OCRProps) {
           body: JSON.stringify({ image: reader.result }),
         });
         if (!res.ok) {
-          throw new Error('OCR Request Failed');
+          throw new Error('영수증 인식에 실패했습니다');
         }
         const data = await res.json();
         toast(`영수증 인식이 완료 되었습니다`);

--- a/fe/src/components/transaction/ReceiptCapture.tsx
+++ b/fe/src/components/transaction/ReceiptCapture.tsx
@@ -9,7 +9,7 @@ interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
 
-export default function OCR({ onResult }: OCRProps) {
+export default function ReceipCapture({ onResult }: OCRProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
 

--- a/fe/src/components/transaction/ReceiptCapture.tsx
+++ b/fe/src/components/transaction/ReceiptCapture.tsx
@@ -5,6 +5,7 @@ import { Receipt } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
+import { Camera } from 'lucide-react';
 interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
@@ -52,10 +53,10 @@ export default function ReceipCapture({ onResult }: OCRProps) {
     <div>
       <Button
         onClick={() => inputRef.current?.click()}
-        className="fixed bottom-0 z-50 m-4 h-16 w-16 cursor-pointer rounded-full"
+        className="h-16 w-16 cursor-pointer rounded-full hover:bg-gray-800"
         asChild
       >
-        {loading ? <Spinner /> : <Receipt size={20} />}
+        {loading ? <Spinner /> : <Camera size={12} />}
       </Button>
       <input
         ref={inputRef}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -178,6 +178,20 @@ export default function ReceiptMulti() {
       setLoading(false);
     }
   };
+
+  const updateResult = (
+    index: number,
+    field: keyof OCRResult,
+    value: string | number
+  ) => {
+    setResults((prev) =>
+      prev.map((item, i) =>
+        i === index
+          ? { ...item, result: { ...item.result, [field]: value } }
+          : item
+      )
+    );
+  };
   return (
     <>
       <Dialog
@@ -271,7 +285,9 @@ export default function ReceiptMulti() {
                           <Label className="w-20 shrink-0">거래처</Label>
                           <Input
                             value={item.result.title}
-                            onChange={(e) => {}}
+                            onChange={(e) =>
+                              updateResult(index, 'title', e.target.value)
+                            }
                             placeholder="가게명"
                           />
                         </div>
@@ -285,6 +301,7 @@ export default function ReceiptMulti() {
                             }
                             onChange={(date) => {
                               const formatted = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+                              updateResult(index, 'date', formatted);
                             }}
                             hideLabel
                           />
@@ -296,7 +313,13 @@ export default function ReceiptMulti() {
                             <Input
                               type="number"
                               value={item.result.amount}
-                              onChange={(e) => {}}
+                              onChange={(e) =>
+                                updateResult(
+                                  index,
+                                  'amount',
+                                  Number(e.target.value)
+                                )
+                              }
                               placeholder="금액"
                             />
                             <span className="text-muted-foreground ml-2 text-sm">
@@ -327,7 +350,13 @@ export default function ReceiptMulti() {
                                 {CATEGORIES.expense.map((cat) => (
                                   <div
                                     key={cat.category_key}
-                                    onClick={() => {}}
+                                    onClick={() => {
+                                      updateResult(
+                                        index,
+                                        'category_id',
+                                        cat.category_key
+                                      );
+                                    }}
                                     className="flex h-12 w-20 cursor-pointer items-center justify-center text-center text-sm hover:bg-gray-100"
                                   >
                                     {cat.name_ko}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -1,11 +1,10 @@
 'use client';
 import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
-import { Receipt, Images, Upload, X } from 'lucide-react';
+import { Images, Upload, X } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
-import Image from 'next/image';
 import { supabase } from '@/utils/supabase/client';
 import { Input } from '../ui/input';
 import { DatePicker } from './common/DatePicker';
@@ -23,13 +22,8 @@ import {
   DialogHeader,
   DialogTrigger,
 } from '../ui/dialog';
-import { TitleInput } from './common/TitleInput';
-import { read } from 'fs';
 import { Progress } from '@/components/ui/progress';
 import { Label } from '../ui/label';
-interface OCRProps {
-  onResult: (data: OCRResult) => void;
-}
 
 interface ResultWithPreview {
   result: OCRResult;
@@ -196,14 +190,14 @@ export default function ReceiptMulti() {
         .insert(transactionsData);
 
       if (error) {
-        toast.error('인식 실패');
+        toast.error('등록 실패');
         return;
       }
 
-      toast.success(`인식 완료!`);
+      toast.success(`등록 완료!`);
       setOpen(false);
     } catch (error) {
-      toast.error('인식 중 오류가 발생했습니다');
+      toast.error('등록 중 오류가 발생했습니다');
     } finally {
       setLoading(false);
     }

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
-import { Receipt } from 'lucide-react';
-import { Images } from 'lucide-react';
+import { Receipt, Images, Upload, X } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
+
 import {
   Dialog,
   DialogContent,
@@ -20,7 +20,17 @@ interface OCRProps {
 export default function ReceiptMulti({ onResult }: OCRProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [files, setFiles] = useState<File[]>();
+  const inputRef = useRef<HTMLInputElement>(null);
 
+  console.log(files);
+  const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(e.target.files || []);
+    setFiles(selectedFiles);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
   return (
     <Dialog
       open={open}
@@ -40,6 +50,23 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
         <DialogHeader>
           <DialogTitle>영수증 업로드</DialogTitle>
         </DialogHeader>
+        <Button onClick={() => inputRef.current?.click()}>
+          내 PC/갤러리에서 찾기
+        </Button>
+        <div className="cursor-pointer rounded-lg border-2 border-dashed p-16 text-center">
+          <Upload className="text-muted-foreground mx-auto mb-2" />
+          <p className="text-muted-foreground">
+            업로드 할 이미지를 드래그해주세요{' '}
+          </p>
+          <input
+            onChange={handleFiles}
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -7,6 +7,7 @@ import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
 import Image from 'next/image';
 import { supabase } from '@/utils/supabase/client';
+import { Input } from '../ui/input';
 
 import {
   Dialog,
@@ -20,6 +21,11 @@ interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
 
+interface ResultWithPreview {
+  result: OCRResult;
+  preview: string;
+}
+
 export default function ReceiptMulti() {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -27,7 +33,7 @@ export default function ReceiptMulti() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [previews, setPreviews] = useState<string[]>([]);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [results, setResults] = useState<OCRResult[]>([]);
+  const [results, setResults] = useState<ResultWithPreview[]>([]);
   const [step, setStep] = useState<'upload' | 'result'>('upload');
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
@@ -75,7 +81,7 @@ export default function ReceiptMulti() {
       return;
     }
 
-    const ocrResults: OCRResult[] = [];
+    const ocrResults: ResultWithPreview[] = [];
     const errors: number[] = [];
 
     setLoading(true);
@@ -95,7 +101,10 @@ export default function ReceiptMulti() {
         }
 
         const data = await res.json();
-        ocrResults.push(data);
+        ocrResults.push({
+          result: data,
+          preview: previews[i],
+        });
       } catch {
         errors.push(i + 1);
       }
@@ -136,11 +145,11 @@ export default function ReceiptMulti() {
 
       const transactionsData = results.map((item) => ({
         user_id: user.id,
-        title: item.title,
+        title: item.result.title,
         type: 'expense',
-        amount: Number(item.amount),
-        date: item.date,
-        category_id: item.category_id,
+        amount: Number(item.result.amount),
+        date: item.result.date,
+        category_id: item.result.category_id,
         tags: null,
       }));
 
@@ -227,26 +236,6 @@ export default function ReceiptMulti() {
                   </div>
                 </>
               )}
-              {/* 이미지 상세보기 overlay */}
-              {selectedImage && (
-                <div
-                  className="round-lg absolute inset-0 flex items-center justify-center bg-black/70"
-                  onClick={() => setSelectedImage(null)}
-                >
-                  <Button
-                    className="absolute bottom-4 h-16 w-16 cursor-pointer rounded-full text-white"
-                    onClick={() => setSelectedImage(null)}
-                    asChild
-                  >
-                    <X size={12} />
-                  </Button>
-                  <img
-                    src={selectedImage}
-                    className="max-h-96 max-w-96 object-contain"
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </div>
-              )}
               <Button
                 onClick={handleUpload}
                 disabled={loading || files.length === 0}
@@ -261,26 +250,42 @@ export default function ReceiptMulti() {
                 <p className="text-muted-foreground text-md">
                   총 {results.length}건
                 </p>
-                {results.map((result, index) => (
-                  <div key={index} className="space-y-2 rounded-lg border p-4">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium">{result.title}</span>
-                      <span className="text-muted-foreground text-sm">
-                        {typeof result.date === 'string'
-                          ? result.date
-                          : new Date(result.date).toLocaleDateString()}
-                      </span>
+                <div>
+                  {results.map((item, index) => (
+                    <div
+                      key={index}
+                      className="space-y-2 rounded-lg border p-4"
+                    >
+                      <img
+                        src={item.preview}
+                        onClick={() => setSelectedImage(item.preview)}
+                        className="h-16 w-12 cursor-pointer rounded object-cover hover:opacity-70"
+                      />
+                      <div className="space-y-2">
+                        <Input
+                          value={item.result.title}
+                          onChange={(e) => {}}
+                          placeholder="가게명"
+                        />
+                        <Input
+                          type="date"
+                          value={
+                            typeof item.result.date === 'string'
+                              ? item.result.date
+                              : ''
+                          }
+                          onChange={(e) => {}}
+                        />
+                        <Input
+                          type="number"
+                          value={item.result.amount}
+                          onChange={(e) => {}}
+                          placeholder="금액"
+                        />
+                      </div>
                     </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-muted-foreground text-sm">
-                        {result.category_id}
-                      </span>
-                      <span className="font-bold">
-                        {result.amount.toLocaleString()}원
-                      </span>
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
                 <Button
                   disabled={loading || results.length === 0}
                   onClick={handleSubmit}
@@ -289,6 +294,26 @@ export default function ReceiptMulti() {
                 </Button>
               </div>
             </>
+          )}
+          {/* 이미지 상세보기 overlay */}
+          {selectedImage && (
+            <div
+              className="round-lg absolute inset-0 flex items-center justify-center bg-black/70"
+              onClick={() => setSelectedImage(null)}
+            >
+              <Button
+                className="absolute bottom-4 h-16 w-16 cursor-pointer rounded-full text-white"
+                onClick={() => setSelectedImage(null)}
+                asChild
+              >
+                <X size={12} />
+              </Button>
+              <img
+                src={selectedImage}
+                className="max-h-96 max-w-96 object-contain"
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Receipt } from 'lucide-react';
+import { Images } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
@@ -28,7 +29,12 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
       }}
     >
       <DialogTrigger asChild>
-        <Button asChild>{loading ? <Spinner /> : <Receipt size={20} />}</Button>
+        <Button
+          className="h-16 w-16 cursor-pointer rounded-full hover:bg-gray-800"
+          asChild
+        >
+          {loading ? <Spinner /> : <Images size={12} />}
+        </Button>
       </DialogTrigger>
       <DialogContent className="max-w-lg">
         <DialogHeader>

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/utils/supabase/client';
 import { Input } from '../ui/input';
 import { DatePicker } from './common/DatePicker';
 import { Checkbox } from '../ui/checkbox';
+import { formatLocalDate } from '@/utils/date';
 import {
   Popover,
   PopoverContent,
@@ -353,7 +354,7 @@ export default function ReceiptMulti() {
                                 : item.result.date
                             }
                             onChange={(date) => {
-                              const formatted = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+                              const formatted = formatLocalDate(date);
                               updateResult(index, 'date', formatted);
                             }}
                             hideLabel

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -24,6 +24,7 @@ import {
 } from '../ui/dialog';
 import { TitleInput } from './common/TitleInput';
 import { read } from 'fs';
+import { Progress } from '@/components/ui/progress';
 import { Label } from '../ui/label';
 interface OCRProps {
   onResult: (data: OCRResult) => void;
@@ -43,6 +44,8 @@ export default function ReceiptMulti() {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [results, setResults] = useState<ResultWithPreview[]>([]);
   const [step, setStep] = useState<'upload' | 'result'>('upload');
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -93,6 +96,7 @@ export default function ReceiptMulti() {
     const errors: number[] = [];
 
     setLoading(true);
+    setProgress({ current: 0, total: files.length });
 
     for (let i = 0; i < files.length; i++) {
       toast(`${i} 번째`);
@@ -116,6 +120,8 @@ export default function ReceiptMulti() {
       } catch {
         errors.push(i + 1);
       }
+
+      setProgress({ current: i + 1, total: files.length });
     }
 
     setLoading(false);
@@ -134,7 +140,7 @@ export default function ReceiptMulti() {
   // 가계부 업로드
   const handleSubmit = async () => {
     if (results.length === 0) {
-      toast.error('저장할 데이터가 없습니다');
+      toast.error('인식할 데이터가 없습니다');
       return;
     }
 
@@ -166,14 +172,14 @@ export default function ReceiptMulti() {
         .insert(transactionsData);
 
       if (error) {
-        toast.error('저장 실패');
+        toast.error('인식 실패');
         return;
       }
 
-      toast.success(`${results.length} 건 저장 완료`);
+      toast.success(`인식 완료!`);
       setOpen(false);
     } catch (error) {
-      toast.error('저장 중 오류가 발생했습니다');
+      toast.error('인식 중 오류가 발생했습니다');
     } finally {
       setLoading(false);
     }
@@ -257,6 +263,14 @@ export default function ReceiptMulti() {
                     ))}
                   </div>
                 </>
+              )}
+              {loading && (
+                <div className="space-y-2">
+                  <Progress value={(progress.current / progress.total) * 100} />
+                  <p className="text-muted-foreground text-center text-sm">
+                    {progress.current} / {progress.total} 처리 중...
+                  </p>
+                </div>
               )}
               <Button
                 onClick={handleUpload}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
 import Image from 'next/image';
+import { supabase } from '@/utils/supabase/client';
 
 import {
   Dialog,
@@ -110,6 +111,54 @@ export default function ReceiptMulti() {
       toast.success(`${results.length}개 영수증 인식 완료`);
       setResults(ocrResults);
       setStep('result');
+    }
+  };
+
+  // 가계부 업로드
+  const handleSubmit = async () => {
+    if (results.length === 0) {
+      toast.error('저장할 데이터가 없습니다');
+      return;
+    }
+
+    try {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+
+      if (!user || authError) {
+        toast.warning('로그인이 필요합니다');
+        return;
+      }
+
+      setLoading(true);
+
+      const transactionsData = results.map((item) => ({
+        user_id: user.id,
+        title: item.title,
+        type: 'expense',
+        amount: Number(item.amount),
+        date: item.date,
+        category_id: item.category_id,
+        tags: null,
+      }));
+
+      const { error } = await supabase
+        .from('transactions')
+        .insert(transactionsData);
+
+      if (error) {
+        toast.error('저장 실패');
+        return;
+      }
+
+      toast.success(`${results.length} 건 저장 완료`);
+      setOpen(false);
+    } catch (error) {
+      toast.error('저장 중 오류가 발생했습니다');
+    } finally {
+      setLoading(false);
     }
   };
   return (
@@ -232,6 +281,12 @@ export default function ReceiptMulti() {
                     </div>
                   </div>
                 ))}
+                <Button
+                  disabled={loading || results.length === 0}
+                  onClick={handleSubmit}
+                >
+                  {loading ? '등록 중...' : '전체 등록'}
+                </Button>
               </div>
             </>
           )}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -9,6 +9,7 @@ import Image from 'next/image';
 import { supabase } from '@/utils/supabase/client';
 import { Input } from '../ui/input';
 import { DatePicker } from './common/DatePicker';
+import { Checkbox } from '../ui/checkbox';
 import {
   Popover,
   PopoverContent,
@@ -59,11 +60,11 @@ export default function ReceiptMulti() {
     });
   };
 
-  const toggleAll = () => {
-    if (checkedItems.size === results.length) {
-      setCheckedItems(new Set());
-    } else {
+  const toggleAll = (checked: boolean | 'indeterminate') => {
+    if (checked === true) {
       setCheckedItems(new Set(results.map((_, i) => i)));
+    } else {
+      setCheckedItems(new Set());
     }
   };
 
@@ -315,11 +316,9 @@ export default function ReceiptMulti() {
               <div className="max-h-[60vh] space-y-3 overflow-y-auto">
                 <div className="flex items-center justify-between">
                   <label className="flex cursor-pointer items-center gap-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={checkedItems.size === results.length}
-                      onChange={toggleAll}
-                      className="h-4 w-4"
+                      onCheckedChange={toggleAll}
                     />
                     <span className="text-sm">전체 선택</span>
                   </label>
@@ -330,11 +329,10 @@ export default function ReceiptMulti() {
                       key={index}
                       className="flex gap-4 rounded-lg border p-4"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={checkedItems.has(index)}
-                        onChange={() => toggleCheck(index)}
-                        className="top-4 right-4 h-5 w-5 cursor-pointer"
+                        onCheckedChange={() => toggleCheck(index)}
+                        className="h-5 w-5"
                       />
                       <img
                         src={item.preview}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -224,7 +224,7 @@ export default function ReceiptMulti() {
         <DialogContent className="max-w-lg overflow-hidden border-none">
           <DialogHeader>
             <DialogTitle>
-              {step === 'upload' ? '영수증 업로드' : '인식 결과'}
+              {step === 'upload' ? `영수증 업로드` : '인식 결과'}
             </DialogTitle>
           </DialogHeader>
           {step === 'upload' && (
@@ -249,9 +249,6 @@ export default function ReceiptMulti() {
               {/* 미리보기 영역 */}
               {previews.length > 0 && (
                 <>
-                  <p className="text-muted-foreground">
-                    {previews.length}개의 이미지
-                  </p>
                   <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
                     {previews.map((src, index) => (
                       <div key={index} className="group relative">
@@ -283,7 +280,9 @@ export default function ReceiptMulti() {
                 onClick={handleUpload}
                 disabled={loading || files.length === 0}
               >
-                {loading ? '처리 중...' : `영수증 업로드`}
+                {loading
+                  ? '처리 중...'
+                  : `${previews.length}개의 영수증 업로드`}
               </Button>
             </>
           )}
@@ -394,8 +393,11 @@ export default function ReceiptMulti() {
                 <Button
                   disabled={loading || results.length === 0}
                   onClick={handleSubmit}
+                  className="w-full"
                 >
-                  {loading ? '등록 중...' : '전체 등록'}
+                  {loading
+                    ? '등록 중...'
+                    : `${results.length}개 데이터 가계부 등록`}
                 </Button>
               </div>
             </>

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -19,13 +19,14 @@ interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
 
-export default function ReceiptMulti({ onResult }: OCRProps) {
+export default function ReceiptMulti() {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const [previews, setPreviews] = useState<string[]>([]);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [results, setResults] = useState<OCRResult[]>([]);
 
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
@@ -62,6 +63,52 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
     addFiles(selectedFiles);
     if (inputRef.current) {
       inputRef.current.value = '';
+    }
+  };
+
+  // 업로드
+  const handleUpload = async () => {
+    // 파일 없을 때 예외처리
+    if (files.length === 0) {
+      toast.error('업로드 할 파일을 등록해주세요');
+      return;
+    }
+
+    const ocrResults: OCRResult[] = [];
+    const errors: number[] = [];
+
+    setLoading(true);
+
+    for (let i = 0; i < files.length; i++) {
+      toast(`${i} 번째`);
+      try {
+        const base64 = await fileToBase64(files[i]);
+        const res = await fetch('/api/ocr', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: base64 }),
+        });
+
+        if (!res.ok) {
+          throw new Error('영수증 인식에 실패했습니다');
+        }
+
+        const data = await res.json();
+        ocrResults.push(data);
+      } catch {
+        errors.push(i + 1);
+      }
+    }
+
+    setLoading(false);
+
+    if (errors.length > 0) {
+      toast.error(`${errors.join(', ')}번째 영수증 인식 실패`);
+    }
+
+    if (ocrResults.length > 0) {
+      toast.success(`${results.length}개 영수증 인식 완료`);
+      setResults(ocrResults);
     }
   };
   return (
@@ -145,6 +192,38 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
                 onClick={(e) => e.stopPropagation()}
               />
             </div>
+          )}
+          <Button
+            onClick={handleUpload}
+            disabled={loading || files.length === 0}
+          >
+            {loading ? '처리 중...' : `영수증 업로드`}
+          </Button>
+          {results.length > 0 && (
+            <>
+              <div className="space-y-3 overflow-y-auto">
+                {results.map((result, index) => (
+                  <div key={index} className="space-y-2 rounded-lg border p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{result.title}</span>
+                      <span className="text-muted-foreground text-sm">
+                        {typeof result.date === 'string'
+                          ? result.date
+                          : new Date(result.date).toLocaleDateString()}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-muted-foreground text-sm">
+                        {result.category_id}
+                      </span>
+                      <span className="font-bold">
+                        {result.amount.toLocaleString()}원
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
           )}
         </DialogContent>
       </Dialog>

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -116,7 +116,6 @@ export default function ReceiptMulti() {
     setProgress({ current: 0, total: files.length });
 
     for (let i = 0; i < files.length; i++) {
-      toast(`${i} 번째`);
       try {
         const base64 = await fileToBase64(files[i]);
         const res = await fetch('/api/ocr', {
@@ -150,6 +149,7 @@ export default function ReceiptMulti() {
     if (ocrResults.length > 0) {
       toast.success(`${results.length}개 영수증 인식 완료`);
       setResults(ocrResults);
+      setCheckedItems(new Set(ocrResults.map((_, i) => i)));
       setStep('result');
     }
   };

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -5,6 +5,7 @@ import { Receipt, Images, Upload, X } from 'lucide-react';
 import { Spinner } from '../ui/spinner';
 import { OCRResult } from '@/types/transactions';
 import { toast } from 'sonner';
+import Image from 'next/image';
 
 import {
   Dialog,
@@ -21,8 +22,9 @@ interface OCRProps {
 export default function ReceiptMulti({ onResult }: OCRProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [files, setFiles] = useState<File[]>();
+  const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [previews, setPreviews] = useState<string[]>([]);
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -40,6 +42,17 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
       return;
     }
     setFiles((prev) => [...(prev || []), ...imgFiles]);
+
+    //미리보기 생성
+    const newPreviews = await Promise.all(
+      imgFiles.map((file) => fileToBase64(file))
+    );
+    setPreviews((prev) => [...prev, ...newPreviews]);
+  };
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+    setPreviews((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -85,6 +98,24 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
             hidden
           />
         </div>
+        {previews.length > 0 && (
+          <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
+            {previews.map((src, index) => (
+              <div key={index} className="group relative">
+                <img
+                  src={src}
+                  className="h-30 w-full rounded object-cover hover:opacity-60"
+                />
+                <button
+                  onClick={() => removeFile(index)}
+                  className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -198,14 +198,21 @@ export default function ReceiptMulti() {
       )
     );
   };
+
+  const reset = () => {
+    setFiles([]);
+    setPreviews([]);
+    setResults([]);
+    setStep('upload');
+    setSelectedImage(null);
+  };
+  const handleClose = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) reset();
+  };
   return (
     <>
-      <Dialog
-        open={open}
-        onOpenChange={(isOpen) => {
-          setOpen(isOpen);
-        }}
-      >
+      <Dialog open={open} onOpenChange={handleClose}>
         <DialogTrigger asChild>
           <Button
             className="h-16 w-16 cursor-pointer rounded-full hover:bg-gray-800"

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -25,6 +25,8 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
   const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const [previews, setPreviews] = useState<string[]>([]);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -63,66 +65,89 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
     }
   };
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(isOpen) => {
-        setOpen(isOpen);
-      }}
-    >
-      <DialogTrigger asChild>
-        <Button
-          className="h-16 w-16 cursor-pointer rounded-full hover:bg-gray-800"
-          asChild
-        >
-          {loading ? <Spinner /> : <Images size={12} />}
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>영수증 업로드</DialogTitle>
-        </DialogHeader>
-        <Button onClick={() => inputRef.current?.click()}>
-          내 PC/갤러리에서 찾기
-        </Button>
-        <div className="cursor-pointer rounded-lg border-2 border-dashed p-16 text-center">
-          <Upload className="text-muted-foreground mx-auto mb-2" />
-          <p className="text-muted-foreground">
-            업로드 할 이미지를 드래그해주세요{' '}
-          </p>
-          <input
-            onChange={handleFiles}
-            ref={inputRef}
-            type="file"
-            accept="image/*"
-            multiple
-            hidden
-          />
-        </div>
-        {/* 미리보기 영역 */}
-        {previews.length > 0 && (
-          <>
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(isOpen) => {
+          setOpen(isOpen);
+        }}
+      >
+        <DialogTrigger asChild>
+          <Button
+            className="h-16 w-16 cursor-pointer rounded-full hover:bg-gray-800"
+            asChild
+          >
+            {loading ? <Spinner /> : <Images size={12} />}
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="max-w-lg overflow-hidden border-none">
+          <DialogHeader>
+            <DialogTitle>영수증 업로드</DialogTitle>
+          </DialogHeader>
+          <Button onClick={() => inputRef.current?.click()}>
+            내 PC/갤러리에서 찾기
+          </Button>
+          <div className="cursor-pointer rounded-lg border-2 border-dashed p-16 text-center">
+            <Upload className="text-muted-foreground mx-auto mb-2" />
             <p className="text-muted-foreground">
-              {previews.length}개의 이미지
+              업로드 할 이미지를 드래그해주세요{' '}
             </p>
-            <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
-              {previews.map((src, index) => (
-                <div key={index} className="group relative">
-                  <img
-                    src={src}
-                    className="h-30 w-full rounded object-cover hover:opacity-60"
-                  />
-                  <button
-                    onClick={() => removeFile(index)}
-                    className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
-                  >
-                    <X size={16} />
-                  </button>
-                </div>
-              ))}
+            <input
+              onChange={handleFiles}
+              ref={inputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              hidden
+            />
+          </div>
+          {/* 미리보기 영역 */}
+          {previews.length > 0 && (
+            <>
+              <p className="text-muted-foreground">
+                {previews.length}개의 이미지
+              </p>
+              <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
+                {previews.map((src, index) => (
+                  <div key={index} className="group relative">
+                    <img
+                      src={src}
+                      onClick={() => setSelectedImage(src)}
+                      className="h-30 w-full rounded object-cover hover:opacity-60"
+                    />
+                    <button
+                      onClick={() => removeFile(index)}
+                      className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
+                    >
+                      <X size={16} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+          {/* 이미지 상세보기 overlay */}
+          {selectedImage && (
+            <div
+              className="round-lg absolute inset-0 flex items-center justify-center bg-black/70"
+              onClick={() => setSelectedImage(null)}
+            >
+              <Button
+                className="absolute bottom-4 h-16 w-16 cursor-pointer rounded-full text-white"
+                onClick={() => setSelectedImage(null)}
+                asChild
+              >
+                <X size={12} />
+              </Button>
+              <img
+                src={selectedImage}
+                className="max-h-96 max-w-96 object-contain"
+                onClick={(e) => e.stopPropagation()}
+              />
             </div>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -8,7 +8,13 @@ import { toast } from 'sonner';
 import Image from 'next/image';
 import { supabase } from '@/utils/supabase/client';
 import { Input } from '../ui/input';
-
+import { DatePicker } from './common/DatePicker';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { CATEGORIES } from '@/constants/categories';
 import {
   Dialog,
   DialogContent,
@@ -16,7 +22,9 @@ import {
   DialogHeader,
   DialogTrigger,
 } from '../ui/dialog';
+import { TitleInput } from './common/TitleInput';
 import { read } from 'fs';
+import { Label } from '../ui/label';
 interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
@@ -246,42 +254,89 @@ export default function ReceiptMulti() {
           )}
           {step === 'result' && (
             <>
-              <div className="space-y-3 overflow-y-auto">
-                <p className="text-muted-foreground text-md">
-                  총 {results.length}건
-                </p>
-                <div>
+              <div className="max-h-[60vh] space-y-3 overflow-y-auto">
+                <div className="flex flex-col gap-2">
                   {results.map((item, index) => (
                     <div
                       key={index}
-                      className="space-y-2 rounded-lg border p-4"
+                      className="flex gap-4 rounded-lg border p-4"
                     >
                       <img
                         src={item.preview}
                         onClick={() => setSelectedImage(item.preview)}
-                        className="h-16 w-12 cursor-pointer rounded object-cover hover:opacity-70"
+                        className="h-32 w-24 cursor-pointer rounded object-cover hover:opacity-70"
                       />
-                      <div className="space-y-2">
-                        <Input
-                          value={item.result.title}
-                          onChange={(e) => {}}
-                          placeholder="가게명"
-                        />
-                        <Input
-                          type="date"
-                          value={
-                            typeof item.result.date === 'string'
-                              ? item.result.date
-                              : ''
-                          }
-                          onChange={(e) => {}}
-                        />
-                        <Input
-                          type="number"
-                          value={item.result.amount}
-                          onChange={(e) => {}}
-                          placeholder="금액"
-                        />
+                      <div className="flex flex-1 flex-col gap-2">
+                        <div className="flex items-center">
+                          <Label className="w-20 shrink-0">거래처</Label>
+                          <Input
+                            value={item.result.title}
+                            onChange={(e) => {}}
+                            placeholder="가게명"
+                          />
+                        </div>
+                        <div className="flex items-center">
+                          <Label className="w-20 shrink-0">날짜</Label>
+                          <DatePicker
+                            value={
+                              typeof item.result.date === 'string'
+                                ? new Date(item.result.date)
+                                : item.result.date
+                            }
+                            onChange={(date) => {
+                              const formatted = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+                            }}
+                            hideLabel
+                          />
+                        </div>
+
+                        <div className="flex gap-4">
+                          <div className="flex items-center">
+                            <Label className="w-20 shrink-0">금액</Label>
+                            <Input
+                              type="number"
+                              value={item.result.amount}
+                              onChange={(e) => {}}
+                              placeholder="금액"
+                            />
+                            <span className="text-muted-foreground ml-2 text-sm">
+                              원
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex items-center">
+                          <Label className="w-20 shrink-0">카테고리</Label>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1 justify-start text-center"
+                              >
+                                {item.result.category_id
+                                  ? CATEGORIES.expense.find(
+                                      (cat) =>
+                                        cat.category_key ===
+                                        item.result.category_id
+                                    )?.name_ko || '선택'
+                                  : '선택'}
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-auto p-0" align="end">
+                              <div className="grid grid-cols-3">
+                                {CATEGORIES.expense.map((cat) => (
+                                  <div
+                                    key={cat.category_key}
+                                    onClick={() => {}}
+                                    className="flex h-12 w-20 cursor-pointer items-center justify-center text-center text-sm hover:bg-gray-100"
+                                  >
+                                    {cat.name_ko}
+                                  </div>
+                                ))}
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
                       </div>
                     </div>
                   ))}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTrigger,
 } from '../ui/dialog';
+import { read } from 'fs';
 interface OCRProps {
   onResult: (data: OCRResult) => void;
 }
@@ -22,11 +23,28 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
   const [loading, setLoading] = useState(false);
   const [files, setFiles] = useState<File[]>();
   const inputRef = useRef<HTMLInputElement>(null);
+  // 이미지를 base64 문자열로 변환
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
 
-  console.log(files);
+  const addFiles = async (newFiles: File[]) => {
+    const imgFiles = newFiles.filter((file) => file.type.startsWith('image/')); // 이미지 아닌 파일은 걸러내기
+    if (imgFiles.length === 0) {
+      toast.error('이미지 파일만 업로드 가능합니다');
+      return;
+    }
+    setFiles((prev) => [...(prev || []), ...imgFiles]);
+  };
+
   const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = Array.from(e.target.files || []);
-    setFiles(selectedFiles);
+    addFiles(selectedFiles);
     if (inputRef.current) {
       inputRef.current.value = '';
     }

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -27,7 +27,7 @@ export default function ReceiptMulti() {
   const [previews, setPreviews] = useState<string[]>([]);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [results, setResults] = useState<OCRResult[]>([]);
-
+  const [step, setStep] = useState<'upload' | 'result'>('upload');
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -109,6 +109,7 @@ export default function ReceiptMulti() {
     if (ocrResults.length > 0) {
       toast.success(`${results.length}개 영수증 인식 완료`);
       setResults(ocrResults);
+      setStep('result');
     }
   };
   return (
@@ -129,79 +130,88 @@ export default function ReceiptMulti() {
         </DialogTrigger>
         <DialogContent className="max-w-lg overflow-hidden border-none">
           <DialogHeader>
-            <DialogTitle>영수증 업로드</DialogTitle>
+            <DialogTitle>
+              {step === 'upload' ? '영수증 업로드' : '인식 결과'}
+            </DialogTitle>
           </DialogHeader>
-          <Button onClick={() => inputRef.current?.click()}>
-            내 PC/갤러리에서 찾기
-          </Button>
-          <div className="cursor-pointer rounded-lg border-2 border-dashed p-16 text-center">
-            <Upload className="text-muted-foreground mx-auto mb-2" />
-            <p className="text-muted-foreground">
-              업로드 할 이미지를 드래그해주세요{' '}
-            </p>
-            <input
-              onChange={handleFiles}
-              ref={inputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              hidden
-            />
-          </div>
-          {/* 미리보기 영역 */}
-          {previews.length > 0 && (
+          {step === 'upload' && (
             <>
-              <p className="text-muted-foreground">
-                {previews.length}개의 이미지
-              </p>
-              <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
-                {previews.map((src, index) => (
-                  <div key={index} className="group relative">
-                    <img
-                      src={src}
-                      onClick={() => setSelectedImage(src)}
-                      className="h-30 w-full rounded object-cover hover:opacity-60"
-                    />
-                    <button
-                      onClick={() => removeFile(index)}
-                      className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
-                    >
-                      <X size={16} />
-                    </button>
-                  </div>
-                ))}
+              <Button onClick={() => inputRef.current?.click()}>
+                내 PC/갤러리에서 찾기
+              </Button>
+              <div className="cursor-pointer rounded-lg border-2 border-dashed p-16 text-center">
+                <Upload className="text-muted-foreground mx-auto mb-2" />
+                <p className="text-muted-foreground">
+                  업로드 할 이미지를 드래그해주세요{' '}
+                </p>
+                <input
+                  onChange={handleFiles}
+                  ref={inputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  hidden
+                />
               </div>
+              {/* 미리보기 영역 */}
+              {previews.length > 0 && (
+                <>
+                  <p className="text-muted-foreground">
+                    {previews.length}개의 이미지
+                  </p>
+                  <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
+                    {previews.map((src, index) => (
+                      <div key={index} className="group relative">
+                        <img
+                          src={src}
+                          onClick={() => setSelectedImage(src)}
+                          className="h-30 w-full rounded object-cover hover:opacity-60"
+                        />
+                        <button
+                          onClick={() => removeFile(index)}
+                          className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
+                        >
+                          <X size={16} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+              {/* 이미지 상세보기 overlay */}
+              {selectedImage && (
+                <div
+                  className="round-lg absolute inset-0 flex items-center justify-center bg-black/70"
+                  onClick={() => setSelectedImage(null)}
+                >
+                  <Button
+                    className="absolute bottom-4 h-16 w-16 cursor-pointer rounded-full text-white"
+                    onClick={() => setSelectedImage(null)}
+                    asChild
+                  >
+                    <X size={12} />
+                  </Button>
+                  <img
+                    src={selectedImage}
+                    className="max-h-96 max-w-96 object-contain"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              )}
+              <Button
+                onClick={handleUpload}
+                disabled={loading || files.length === 0}
+              >
+                {loading ? '처리 중...' : `영수증 업로드`}
+              </Button>
             </>
           )}
-          {/* 이미지 상세보기 overlay */}
-          {selectedImage && (
-            <div
-              className="round-lg absolute inset-0 flex items-center justify-center bg-black/70"
-              onClick={() => setSelectedImage(null)}
-            >
-              <Button
-                className="absolute bottom-4 h-16 w-16 cursor-pointer rounded-full text-white"
-                onClick={() => setSelectedImage(null)}
-                asChild
-              >
-                <X size={12} />
-              </Button>
-              <img
-                src={selectedImage}
-                className="max-h-96 max-w-96 object-contain"
-                onClick={(e) => e.stopPropagation()}
-              />
-            </div>
-          )}
-          <Button
-            onClick={handleUpload}
-            disabled={loading || files.length === 0}
-          >
-            {loading ? '처리 중...' : `영수증 업로드`}
-          </Button>
-          {results.length > 0 && (
+          {step === 'result' && (
             <>
               <div className="space-y-3 overflow-y-auto">
+                <p className="text-muted-foreground text-md">
+                  총 {results.length}건
+                </p>
                 {results.map((result, index) => (
                   <div key={index} className="space-y-2 rounded-lg border p-4">
                     <div className="flex items-center justify-between">

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -147,7 +147,7 @@ export default function ReceiptMulti() {
     }
 
     if (ocrResults.length > 0) {
-      toast.success(`${results.length}개 영수증 인식 완료`);
+      toast.success(`${ocrResults.length}개 영수증 인식 완료`);
       setResults(ocrResults);
       setCheckedItems(new Set(ocrResults.map((_, i) => i)));
       setStep('result');

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState, useRef } from 'react';
+import { Button } from '../ui/button';
+import { Receipt } from 'lucide-react';
+import { Spinner } from '../ui/spinner';
+import { OCRResult } from '@/types/transactions';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogHeader,
+  DialogTrigger,
+} from '../ui/dialog';
+interface OCRProps {
+  onResult: (data: OCRResult) => void;
+}
+
+export default function ReceiptMulti({ onResult }: OCRProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button asChild>{loading ? <Spinner /> : <Receipt size={20} />}</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>영수증 업로드</DialogTitle>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -98,23 +98,29 @@ export default function ReceiptMulti({ onResult }: OCRProps) {
             hidden
           />
         </div>
+        {/* 미리보기 영역 */}
         {previews.length > 0 && (
-          <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
-            {previews.map((src, index) => (
-              <div key={index} className="group relative">
-                <img
-                  src={src}
-                  className="h-30 w-full rounded object-cover hover:opacity-60"
-                />
-                <button
-                  onClick={() => removeFile(index)}
-                  className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
-                >
-                  <X size={16} />
-                </button>
-              </div>
-            ))}
-          </div>
+          <>
+            <p className="text-muted-foreground">
+              {previews.length}개의 이미지
+            </p>
+            <div className="grid grid-cols-4 gap-6 overflow-y-scroll">
+              {previews.map((src, index) => (
+                <div key={index} className="group relative">
+                  <img
+                    src={src}
+                    className="h-30 w-full rounded object-cover hover:opacity-60"
+                  />
+                  <button
+                    onClick={() => removeFile(index)}
+                    className="bg-destructive absolute top-1 right-1 cursor-pointer rounded-full p-1 text-white opacity-0 group-hover:opacity-60 hover:opacity-95"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -45,6 +45,27 @@ export default function ReceiptMulti() {
   const [results, setResults] = useState<ResultWithPreview[]>([]);
   const [step, setStep] = useState<'upload' | 'result'>('upload');
   const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [checkedItems, setCheckedItems] = useState<Set<number>>(new Set());
+
+  const toggleCheck = (index: number) => {
+    setCheckedItems((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(index)) {
+        newSet.delete(index);
+      } else {
+        newSet.add(index);
+      }
+      return newSet;
+    });
+  };
+
+  const toggleAll = () => {
+    if (checkedItems.size === results.length) {
+      setCheckedItems(new Set());
+    } else {
+      setCheckedItems(new Set(results.map((_, i) => i)));
+    }
+  };
 
   // 이미지를 base64 문자열로 변환
   const fileToBase64 = (file: File): Promise<string> => {
@@ -139,8 +160,8 @@ export default function ReceiptMulti() {
 
   // 가계부 업로드
   const handleSubmit = async () => {
-    if (results.length === 0) {
-      toast.error('인식할 데이터가 없습니다');
+    if (checkedItems.size === 0) {
+      toast.error('가계부에 등록할 데이터를 체크해주세요');
       return;
     }
 
@@ -157,15 +178,17 @@ export default function ReceiptMulti() {
 
       setLoading(true);
 
-      const transactionsData = results.map((item) => ({
-        user_id: user.id,
-        title: item.result.title,
-        type: 'expense',
-        amount: Number(item.result.amount),
-        date: item.result.date,
-        category_id: item.result.category_id,
-        tags: null,
-      }));
+      const transactionsData = results
+        .filter((_, index) => checkedItems.has(index))
+        .map((item) => ({
+          user_id: user.id,
+          title: item.result.title,
+          type: 'expense',
+          amount: Number(item.result.amount),
+          date: item.result.date,
+          category_id: item.result.category_id,
+          tags: null,
+        }));
 
       const { error } = await supabase
         .from('transactions')
@@ -205,6 +228,7 @@ export default function ReceiptMulti() {
     setResults([]);
     setStep('upload');
     setSelectedImage(null);
+    setCheckedItems(new Set());
   };
   const handleClose = (isOpen: boolean) => {
     setOpen(isOpen);
@@ -289,12 +313,29 @@ export default function ReceiptMulti() {
           {step === 'result' && (
             <>
               <div className="max-h-[60vh] space-y-3 overflow-y-auto">
+                <div className="flex items-center justify-between">
+                  <label className="flex cursor-pointer items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={checkedItems.size === results.length}
+                      onChange={toggleAll}
+                      className="h-4 w-4"
+                    />
+                    <span className="text-sm">전체 선택</span>
+                  </label>
+                </div>
                 <div className="flex flex-col gap-2">
                   {results.map((item, index) => (
                     <div
                       key={index}
                       className="flex gap-4 rounded-lg border p-4"
                     >
+                      <input
+                        type="checkbox"
+                        checked={checkedItems.has(index)}
+                        onChange={() => toggleCheck(index)}
+                        className="top-4 right-4 h-5 w-5 cursor-pointer"
+                      />
                       <img
                         src={item.preview}
                         onClick={() => setSelectedImage(item.preview)}
@@ -397,7 +438,7 @@ export default function ReceiptMulti() {
                 >
                   {loading
                     ? '등록 중...'
-                    : `${results.length}개 데이터 가계부 등록`}
+                    : `${checkedItems.size} / ${results.length}개 데이터 등록`}
                 </Button>
               </div>
             </>

--- a/fe/src/components/transaction/common/DatePicker.tsx
+++ b/fe/src/components/transaction/common/DatePicker.tsx
@@ -29,9 +29,9 @@ export const DatePicker = ({
   hideLabel = false,
 }: DatePickerProps) => {
   return (
-    <div className="flex items-center">
+    <div className="flex w-full items-center">
       {!hideLabel && <Label className="w-28 pr-2">{label}</Label>}
-      <div>
+      <div className="w-full">
         <Popover>
           <PopoverTrigger asChild>
             <Button

--- a/fe/src/components/ui/checkbox.tsx
+++ b/fe/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/fe/yarn.lock
+++ b/fe/yarn.lock
@@ -615,6 +615,20 @@
     "@radix-ui/react-use-is-hydrated" "0.1.0"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-checkbox@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz#db45ca8a6d5c056a92f74edbb564acee05318b79"
+  integrity sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-collection@1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"


### PR DESCRIPTION
## PR 개요
영수증 OCR 기능에 다중 파일 업로드 및 일괄 처리 기능을 추가
여러 영수증을 한 번에 인식하고 가계부에 등록할 수 있도록 개선

## 주요 변경사항

### 1. 다중 영수증 처리 기능
- **여러 파일 동시 업로드**: 파일 선택을 통해 다수의 영수증 이미지를 한 번에 업로드
- **OCR 처리**: 업로드된 모든 영수증을 순차적으로 처리하며 실시간 진행률 표시
- **선택적 등록**: 인식 결과를 개별적으로 확인하고 체크박스로 선택하여 원하는 데이터만 가계부에 등록

### 2.  Flow
#### Step 1: Upload
- 이미지 파일 선택 (다중 선택 지원)
- 개별 파일 미리보기 및 삭제 기능
- OCR 처리 진행률 표시 Progress bar 표시

#### Step 2: Result
- 인식된 데이터 목록을 썸네일과 편집 가능한 필드로 표시
- 각 항목별 체크박스로 선택적 등록
- 거래처, 날짜, 금액, 카테고리를 결과 화면에서 직접 수정

### 3. UX 개선사항
- **이미지 상세보기**: 썸네일 클릭 시 오버레이로 확대 이미지 표시
- **상태 피드백**: 
  - 파일 미선택 시 업로드 버튼 비활성화
  - 체크 항목 없을 시 등록 버튼 경고 메시지
  - 로딩 상태 시 버튼 텍스트 변경 및 비활성화

## 리뷰 요청사항
### 기능 테스트
- [ ] 여러 영수증 이미지를 동시에 선택했을 때 미리보기 그리드가 정상적으로 표시되는지
- [ ] 미리보기의 이미지를 클릭했을 때 자세히 보기가 정상 작동되는지
- [ ] 미리보기가 정상적으로 삭제되는지
- [ ] OCR 처리 중 진행률과 toast 메시지가 올바르게 업데이트되는지
- [ ] 인식 결과 화면에서 각 필드(거래처, 날짜, 금액, 카테고리)를 수정할 수 있는지
- [ ] 전체 선택/해제 체크박스가 정상 작동하는지
- [ ] 선택된 항목만 가계부에 등록되는지
- [ ] 다이얼로그를 닫고 다시 열었을 때 모든 상태가 초기화되는지