### PR TITLE
[fix] 스크롤 시 footer가 화면 하단에 고정되지 않는 레이아웃 문제 해결

### DIFF
--- a/fe/src/app/(app)/history/page.tsx
+++ b/fe/src/app/(app)/history/page.tsx
@@ -27,7 +27,7 @@ export default async function Page({ searchParams }: PageProps) {
   return (
     <>
       <TransactionProvider>
-        <div className="flex h-screen w-full flex-col">
+        <div className="flex min-h-screen w-full flex-col">
           <Suspense fallback={<TransactionListSkeleton />}>
             <TransactionListWrapper filters={filters} />
           </Suspense>

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -49,7 +49,7 @@ export default async function Home({ searchParams }: PageProps) {
   );
 
   return (
-    <div className="flex min-h-[900px] w-full max-w-6xl self-start">
+    <div className="flex min-h-screen w-full max-w-6xl self-start">
       <TransactionProvider>
         <CalendarProvider>
           <Suspense fallback={<CalendarSkeleton />}>


### PR DESCRIPTION
## PR 개요
- 스크롤 시 footer가 항상 화면의 최하단에 위치하지 않고, 초기 렌더 시점의 하단 위치에 고정되어 있는 문제를 해결했습니다.

## 변경 사항
- 레이아웃 높이 속성 수정 (`h-screen` → `min-h-screen`)
  - `h-screen` 적용 시 높이가 화면 크기로 고정되어, 콘텐츠가 많아질 경우 `Footer`가 화면 중간에 고정된 채 콘텐츠를 가리는 현상 발생
  - `min-h-screen`으로 변경하여 콘텐츠가 적을 때는 화면을 꽉 채우고, 콘텐츠가 많아질 때는 유연하게 높이가 확장되도록 수정

## 스크린샷 (선택)
| Footer |
|------------|
| ![FooterLayout](https://github.com/user-attachments/assets/8be23daf-867f-4cf0-8025-6958ac931a31) ||

## 리뷰 요청 사항
- Footer가 화면 하단에 올바르게 배치되는지 확인 부탁드립니다
