### PR TITLE
[refactor] 고정비·거래 UI 구조 통일 및 폼 UX 개선

### DIFF
--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -7,7 +7,7 @@ import ResponsivePanel from '@/components/panel/ResponsivePanel';
 import { useRouter } from 'next/navigation';
 import { useSelected } from './TransactionContext';
 import ReceiptCapture from '@/components/transaction/ReceiptCapture';
-import { useState } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { OCRResult } from '@/types/transactions';
 import ReceiptMulti from '@/components/transaction/ReceiptMulti';
 import { Receipt } from 'lucide-react';
@@ -17,17 +17,31 @@ export default function TransactionClient() {
   const router = useRouter();
   const { selectedTransaction, isOpen, openCreate, close } = useSelected();
   const [ocrData, setOcrData] = useState<OCRResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [closeAfterRefresh, setCloseAfterRefresh] = useState(false);
+
+  const handlePanelOpenChange = (open: boolean) => {
+    if (!open) {
+      close();
+      setOcrData(null);
+    }
+  };
 
   const handleSuccess = () => {
-    close();
-    setOcrData(null);
-    router.refresh();
+    setCloseAfterRefresh(true);
+    startTransition(() => {
+      router.refresh();
+    });
   };
 
-  const handleClose = () => {
-    close();
-    setOcrData(null);
-  };
+  useEffect(() => {
+    if (closeAfterRefresh && !isPending) {
+      close();
+      setOcrData(null);
+      setCloseAfterRefresh(false);
+    }
+  }, [closeAfterRefresh, isPending, close]);
+
   const handleOCRResult = (data: OCRResult) => {
     setOcrData(data);
     openCreate();
@@ -48,11 +62,11 @@ export default function TransactionClient() {
       >
         <Plus size={20} />
       </Button>
-      <ResponsivePanel isOpen={isOpen} setIsOpen={handleSuccess}>
+      <ResponsivePanel isOpen={isOpen} setIsOpen={handlePanelOpenChange}>
         <TransactionSubmitForm
           mode={mode}
           transaction={selectedTransaction}
-          onClose={handleClose}
+          onClose={() => handlePanelOpenChange(false)}
           onSuccess={handleSuccess}
           defaultValue={ocrData}
         />

--- a/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
@@ -15,9 +15,10 @@ import {
 
 type Props = {
   onDelete: () => void | Promise<void>;
+  disabled?: boolean;
 };
 
-export default function FixedCostDeleteDialog({ onDelete }: Props) {
+export default function FixedCostDeleteDialog({ onDelete, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState(false);
 
@@ -39,6 +40,7 @@ export default function FixedCostDeleteDialog({ onDelete }: Props) {
           variant="outline"
           className="hover:text-destructive"
           aria-label="고정비 규칙 삭제"
+          disabled={disabled || pending}
         >
           <Trash className="h-4 w-4" />
         </Button>

--- a/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostDeleteDialog.tsx
@@ -34,13 +34,14 @@ export default function FixedCostDeleteDialog({ onDelete }: Props) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button
+        <Button
           type="button"
-          className="text-muted-foreground hover:text-destructive inline-flex h-10 w-10 items-center justify-center rounded-md border"
+          variant="outline"
+          className="hover:text-destructive"
           aria-label="고정비 규칙 삭제"
         >
           <Trash className="h-4 w-4" />
-        </button>
+        </Button>
       </DialogTrigger>
 
       <DialogContent>

--- a/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
+++ b/fe/src/components/fixed-costs/FixedCostEditConfirmDialog.tsx
@@ -15,6 +15,7 @@ type FixedCostEditConfirmDialogProps = {
   cycle: 'WEEKLY' | 'MONTHLY';
   onApplyIncludeCurrent: () => void;
   onApplyExcludeCurrent: () => void;
+  pending?: boolean;
 };
 
 export default function FixedCostEditConfirmDialog({
@@ -23,6 +24,7 @@ export default function FixedCostEditConfirmDialog({
   cycle,
   onApplyIncludeCurrent,
   onApplyExcludeCurrent,
+  pending = false,
 }: FixedCostEditConfirmDialogProps) {
   const unit = cycle === 'WEEKLY' ? '이번주' : '이번달';
 
@@ -38,7 +40,11 @@ export default function FixedCostEditConfirmDialog({
 
         <div className="mt-3 flex flex-col gap-3">
           <div className="rounded-md border p-3">
-            <Button className="w-full" onClick={onApplyIncludeCurrent}>
+            <Button
+              className="w-full"
+              onClick={onApplyIncludeCurrent}
+              disabled={pending}
+            >
               {unit} 포함 이후 전부 적용
             </Button>
             <p className="text-muted-foreground mt-1 text-sm">
@@ -51,6 +57,7 @@ export default function FixedCostEditConfirmDialog({
               variant="outline"
               className="w-full"
               onClick={onApplyExcludeCurrent}
+              disabled={pending}
             >
               {unit} 제외 이후 전부 적용
             </Button>

--- a/fe/src/components/fixed-costs/FixedCostItem.tsx
+++ b/fe/src/components/fixed-costs/FixedCostItem.tsx
@@ -6,6 +6,7 @@ import { ChevronRight } from 'lucide-react';
 import { IFixedRule } from '@/types/fixed-costs';
 import { formatFixedRuleCycle } from '@/utils/fixed-costs';
 import { THEME_COLOR } from '@/constants/colors';
+import { CATEGORIES } from '@/constants/categories';
 
 type FixedCostItemProps = {
   rule: IFixedRule;
@@ -17,6 +18,10 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
     onEdit?.(rule);
   };
 
+  const categoryName = CATEGORIES[rule.type].find(
+    (cat) => cat.category_key === rule.category_id
+  )?.name_ko;
+
   return (
     <Item
       variant="outline"
@@ -24,7 +29,8 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
       onClick={handleClick}
     >
       <ItemContent className="flex flex-row items-center">
-        <div className="flex w-24 flex-col gap-1">
+        {/* 좌측: 주기 + 금액 */}
+        <div className="flex w-32 flex-col gap-1">
           <span className="text-muted-foreground text-xs">
             {formatFixedRuleCycle(rule)}
           </span>
@@ -39,8 +45,15 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
           </span>
         </div>
 
-        <ItemTitle className="p-2 text-left">{rule.title}</ItemTitle>
+        {/* 중앙: 카테고리 + 제목 */}
+        <div className="pl-2">
+          <ItemTitle className="text-muted-foreground pl-2 text-left text-xs">
+            {categoryName}
+          </ItemTitle>
+          <ItemTitle className="p-2 text-left">{rule.title}</ItemTitle>
+        </div>
 
+        {/* 우측 */}
         <div className="ml-auto">
           <ChevronRight />
         </div>

--- a/fe/src/components/fixed-costs/FixedCostItem.tsx
+++ b/fe/src/components/fixed-costs/FixedCostItem.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Item, ItemContent, ItemTitle } from '@/components/ui/item';
+import { cn } from '@/lib/utils';
+import { ChevronRight } from 'lucide-react';
+import { IFixedRule } from '@/types/fixed-costs';
+import { formatFixedRuleCycle } from '@/utils/fixed-costs';
+import { THEME_COLOR } from '@/constants/colors';
+
+type FixedCostItemProps = {
+  rule: IFixedRule;
+  onEdit?: (rule: IFixedRule) => void;
+};
+
+export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
+  const handleClick = () => {
+    onEdit?.(rule);
+  };
+
+  return (
+    <Item
+      variant="outline"
+      className="hover:border-brand-soft cursor-pointer transition-colors"
+      onClick={handleClick}
+    >
+      <ItemContent className="flex flex-row items-center">
+        <div className="flex w-24 flex-col gap-1">
+          <span className="text-muted-foreground text-xs">
+            {formatFixedRuleCycle(rule)}
+          </span>
+          <span
+            className={cn(
+              'text-sm font-bold',
+              rule.type === 'income' ? THEME_COLOR.INCOME : THEME_COLOR.EXPENSE
+            )}
+          >
+            {rule.type === 'income' ? '+' : '-'}
+            {rule.amount.toLocaleString()}원
+          </span>
+        </div>
+
+        <ItemTitle className="p-2 text-left">{rule.title}</ItemTitle>
+
+        <div className="ml-auto">
+          <ChevronRight />
+        </div>
+      </ItemContent>
+    </Item>
+  );
+}

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -19,6 +19,7 @@ import {
 import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
 import FixedCostDeleteDialog from './FixedCostDeleteDialog';
+import { Spinner } from '../ui/spinner';
 
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
@@ -36,6 +37,7 @@ export default function FixedCostSubmitForm({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingPayload, setPendingPayload] =
     useState<CreateFixedRuleInput | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const {
     formData,
@@ -47,6 +49,7 @@ export default function FixedCostSubmitForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return; // 중복 제출 방지
 
     const errorMsg = validateFormData();
     if (errorMsg) {
@@ -73,6 +76,7 @@ export default function FixedCostSubmitForm({
       setConfirmOpen(true);
       return;
     }
+    setIsSubmitting(true);
 
     try {
       await createFixedRule(payload);
@@ -80,6 +84,8 @@ export default function FixedCostSubmitForm({
       onSuccess(); // 고정비 목록 갱신
     } catch {
       toast.error('고정비 추가에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -90,7 +96,9 @@ export default function FixedCostSubmitForm({
 
   const handleApplyIncludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
+    if (isSubmitting) return;
 
+    setIsSubmitting(true);
     try {
       await updateFixedRuleWithScope({
         id: ruleId,
@@ -103,12 +111,16 @@ export default function FixedCostSubmitForm({
       onSuccess();
     } catch {
       toast.error('고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleApplyExcludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
+    if (isSubmitting) return;
 
+    setIsSubmitting(true);
     try {
       await updateFixedRuleWithScope({
         id: ruleId,
@@ -121,12 +133,16 @@ export default function FixedCostSubmitForm({
       onSuccess();
     } catch {
       toast.error('고정비 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleDeleteRule = async () => {
     if (!ruleId) return;
+    if (isSubmitting) return;
 
+    setIsSubmitting(true);
     try {
       await deleteFixedRule(ruleId);
       toast.success('고정비 규칙이 삭제되었습니다.');
@@ -135,6 +151,8 @@ export default function FixedCostSubmitForm({
       toast.error(
         '고정비 규칙 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.'
       );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -183,12 +201,14 @@ export default function FixedCostSubmitForm({
         <div className="bg-background sticky bottom-0 z-10 border-t py-4">
           {mode === 'create' ? (
             <Button type="submit" className="w-full">
+              {isSubmitting && <Spinner />}
               저장
             </Button>
           ) : (
             <div className="flex items-center gap-2">
               {ruleId && <FixedCostDeleteDialog onDelete={handleDeleteRule} />}
               <Button type="submit" className="flex-1">
+                {isSubmitting && <Spinner />}
                 수정
               </Button>
             </div>

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -180,7 +180,7 @@ export default function FixedCostSubmitForm({
           />
         </div>
 
-        <div className="bg-background sticky bottom-0 z-10 border-t pt-4 pb-4">
+        <div className="bg-background sticky bottom-0 z-10 border-t py-4">
           {mode === 'create' ? (
             <Button type="submit" className="w-full">
               저장

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -139,23 +139,22 @@ export default function FixedCostSubmitForm({
   };
 
   return (
-    <div className="flex min-h-dvh flex-col px-6">
+    <div className="flex flex-1 flex-col">
       <form
         onSubmit={handleSubmit}
-        className="mx-auto flex min-h-dvh w-full flex-col p-10 pt-2"
+        className="mx-auto flex min-h-full w-full flex-1 flex-col px-10"
       >
-        <div className="sticky top-0 flex items-center justify-between border-b pb-4">
+        <div className="bg-background sticky top-0 z-10 flex items-center justify-between border-b pb-4">
           <Label className="text-xl">
             {mode === 'create' ? '고정비 추가' : '고정비 수정'}
           </Label>
         </div>
 
-        <div className="scrollbar-hide flex-1 space-y-6 overflow-y-auto pt-6 pb-24">
+        <div className="min-h-0 flex-1 space-y-6 py-6">
           <TitleInput
             value={formData.title}
             onChange={(title) => UpdateField('title', title)}
           />
-
           <TypeSelector
             value={formData.type}
             onChange={(type) => {
@@ -163,7 +162,6 @@ export default function FixedCostSubmitForm({
               UpdateField('category_id', '');
             }}
           />
-
           <CategorySelector
             transactionType={formData.type}
             value={formData.category_id}
@@ -171,12 +169,10 @@ export default function FixedCostSubmitForm({
             onOpenChange={setCategoryOpen}
             onChange={(category) => UpdateField('category_id', category)}
           />
-
           <AmountInput
             value={formData.amount}
             onChange={(amount) => UpdateField('amount', amount)}
           />
-
           {/* 고정비 영역 */}
           <FixedCostScheduleFields
             formData={formData}
@@ -184,7 +180,7 @@ export default function FixedCostSubmitForm({
           />
         </div>
 
-        <div className="bg-background sticky bottom-0 border-t pt-4 pb-4">
+        <div className="bg-background sticky bottom-0 z-10 border-t pt-4 pb-4">
           {mode === 'create' ? (
             <Button type="submit" className="w-full">
               저장

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -200,14 +200,19 @@ export default function FixedCostSubmitForm({
 
         <div className="bg-background sticky bottom-0 z-10 border-t py-4">
           {mode === 'create' ? (
-            <Button type="submit" className="w-full">
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
               {isSubmitting && <Spinner />}
               저장
             </Button>
           ) : (
             <div className="flex items-center gap-2">
-              {ruleId && <FixedCostDeleteDialog onDelete={handleDeleteRule} />}
-              <Button type="submit" className="flex-1">
+              {ruleId && (
+                <FixedCostDeleteDialog
+                  onDelete={handleDeleteRule}
+                  disabled={isSubmitting}
+                />
+              )}
+              <Button type="submit" className="flex-1" disabled={isSubmitting}>
                 {isSubmitting && <Spinner />}
                 수정
               </Button>
@@ -222,6 +227,7 @@ export default function FixedCostSubmitForm({
         cycle={formData.cycle as 'WEEKLY' | 'MONTHLY'}
         onApplyIncludeCurrent={handleApplyIncludeCurrent}
         onApplyExcludeCurrent={handleApplyExcludeCurrent}
+        pending={isSubmitting}
       />
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostsAddButton.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsAddButton.tsx
@@ -7,11 +7,11 @@ export default function FixedCostsAddButton({ onClick }: Props) {
   return (
     <Button
       type="button"
-      className="z-50 mr-4 h-12 w-12 rounded-full"
-      size="icon"
+      className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"
       onClick={onClick}
+      asChild
     >
-      <Plus />
+      <Plus size={20} />
     </Button>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -1,5 +1,6 @@
 import FixedCostItem from './FixedCostItem';
 import { IFixedRule } from '@/types/fixed-costs';
+import FixedCostsListSkeleton from './FixedCostsListSkeleton';
 
 type FixedCostsListProps = {
   items: IFixedRule[];
@@ -16,19 +17,15 @@ export default function FixedCostsList({
     <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
       <div className="w-full max-w-xl space-y-6">
         {isLoading ? (
-          <p className="text-muted-foreground py-8 text-center text-sm">
-            고정비 목록을 불러오는 중입니다…
-          </p>
+          <FixedCostsListSkeleton />
         ) : items.length === 0 ? (
           <p className="text-muted-foreground text-center">
             등록된 고정비가 없습니다
           </p>
         ) : (
-          <div className="space-y-2">
-            {items.map((rule) => (
-              <FixedCostItem key={rule.id} rule={rule} onEdit={onEdit} />
-            ))}
-          </div>
+          items.map((rule) => (
+            <FixedCostItem key={rule.id} rule={rule} onEdit={onEdit} />
+          ))
         )}
       </div>
     </div>

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -1,15 +1,5 @@
-import {
-  Item,
-  ItemActions,
-  ItemContent,
-  ItemTitle,
-} from '@/components/ui/item';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { ChevronRight } from 'lucide-react';
+import FixedCostItem from './FixedCostItem';
 import { IFixedRule } from '@/types/fixed-costs';
-import { formatFixedRuleCycle } from '@/utils/fixed-costs';
-import { THEME_COLOR } from '@/constants/colors';
 
 type FixedCostsListProps = {
   items: IFixedRule[];
@@ -43,35 +33,8 @@ export default function FixedCostsList({
 
   return (
     <div className="space-y-2">
-      {items.map((e) => (
-        <Item variant="outline" key={e.id}>
-          <ItemContent className="flex flex-row items-center">
-            <div className="flex w-24 flex-col gap-1">
-              <span className="text-muted-foreground text-xs">
-                {formatFixedRuleCycle(e)}
-              </span>
-              <span
-                className={cn(
-                  'text-sm font-bold',
-                  e.type === 'income' ? THEME_COLOR.INCOME : THEME_COLOR.EXPENSE
-                )}
-              >
-                {e.type === 'income' ? '+' : '-'}
-                {e.amount.toLocaleString()}원
-              </span>
-            </div>
-            <ItemTitle className="p-2 text-left">{e.title}</ItemTitle>
-            <ItemActions className="ml-auto">
-              <Button
-                className="cursor-pointer"
-                size="sm"
-                onClick={() => onEdit(e)}
-              >
-                <ChevronRight />
-              </Button>
-            </ItemActions>
-          </ItemContent>
-        </Item>
+      {items.map((rule) => (
+        <FixedCostItem key={rule.id} rule={rule} onEdit={onEdit} />
       ))}
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -12,30 +12,25 @@ export default function FixedCostsList({
   isLoading,
   onEdit,
 }: FixedCostsListProps) {
-  if (isLoading) {
-    return (
-      <div className="text-muted-foreground py-8 text-center text-sm">
-        고정비 목록을 불러오는 중입니다…
-      </div>
-    );
-  }
-
-  if (items.length === 0) {
-    return (
-      <div className="text-muted-foreground rounded-md border p-6 text-center text-sm whitespace-pre-line">
-        <p>
-          등록된 고정비가 없습니다. <br /> 상단의 + 버튼을 눌러 고정비를 추가해
-          주세요.
-        </p>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-2">
-      {items.map((rule) => (
-        <FixedCostItem key={rule.id} rule={rule} onEdit={onEdit} />
-      ))}
+    <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
+      <div className="w-full max-w-xl space-y-6">
+        {isLoading ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            고정비 목록을 불러오는 중입니다…
+          </p>
+        ) : items.length === 0 ? (
+          <p className="text-muted-foreground text-center">
+            등록된 고정비가 없습니다
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {items.map((rule) => (
+              <FixedCostItem key={rule.id} rule={rule} onEdit={onEdit} />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Item, ItemContent, ItemTitle } from '@/components/ui/item';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type Props = {
+  count?: number;
+};
+
+const FixedCostItemSkeleton = () => (
+  <Item variant="outline">
+    <ItemContent className="flex flex-row items-center">
+      {/* 좌측: 주기 + 금액 */}
+      <div className="flex w-32 flex-col gap-2">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+
+      {/* 중앙: 카테고리 + 제목 */}
+      <div className="pl-2">
+        <ItemTitle className="pl-2">
+          <Skeleton className="h-3 w-24" />
+        </ItemTitle>
+        <ItemTitle className="p-2">
+          <Skeleton className="h-4 w-40" />
+        </ItemTitle>
+      </div>
+
+      {/* 우측: chevron 자리 */}
+      <div className="ml-auto">
+        <Skeleton className="h-8 w-8" />
+      </div>
+    </ItemContent>
+  </Item>
+);
+
+export default function FixedCostsListSkeleton({ count = 5 }: Props) {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: count }).map((_, i) => (
+        <FixedCostItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -54,12 +54,13 @@ export default function FixedCostsPage() {
 
   return (
     <div className="flex min-h-screen w-full flex-col">
+      <FixedCostsAddButton onClick={handleCreateClick} />
+
       <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
         <div className="w-full max-w-xl space-y-6">
           <header>
             <h1 className="text-xl font-semibold">고정비 관리</h1>
           </header>
-          <FixedCostsAddButton onClick={handleCreateClick} />
         </div>
       </div>
 

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -53,8 +53,22 @@ export default function FixedCostsPage() {
   };
 
   return (
-    <div className="mx-auto min-h-screen w-full max-w-lg space-y-6 p-4 md:p-6 lg:p-8">
-      <FixedCostsAddButton onClick={handleCreateClick} />
+    <div className="flex min-h-screen w-full flex-col">
+      <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
+        <div className="w-full max-w-xl space-y-6">
+          <header>
+            <h1 className="text-xl font-semibold">고정비 관리</h1>
+          </header>
+          <FixedCostsAddButton onClick={handleCreateClick} />
+        </div>
+      </div>
+
+      <FixedCostsList
+        items={items}
+        isLoading={isLoading}
+        onEdit={handleEditClick}
+      />
+
       <ResponsivePanel isOpen={isPanelOpen} setIsOpen={setIsPanelOpen}>
         <FixedCostSubmitForm
           mode={formMode}
@@ -65,16 +79,6 @@ export default function FixedCostsPage() {
           onSuccess={handleCreateSuccess}
         />
       </ResponsivePanel>
-
-      <header>
-        <h1 className="text-xl font-semibold">고정비 관리</h1>
-      </header>
-
-      <FixedCostsList
-        items={items}
-        isLoading={isLoading}
-        onEdit={handleEditClick}
-      />
     </div>
   );
 }

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Button } from '../ui/button';
 import { supabase } from '@/utils/supabase/client';
@@ -14,6 +14,7 @@ import { TitleInput } from './common/TitleInput';
 import { TypeSelector } from './common/TypeSelector';
 import { CategorySelector } from './common/CategorySelector';
 import { QuickAmountButtons } from './common/QuickAmountButtons';
+import { Spinner } from '../ui/spinner';
 
 interface TransactionsSubmitFormProps {
   mode: 'create' | 'edit';
@@ -76,6 +77,8 @@ export default function TransactionSubmitForm({
     UpdateField,
   } = useTransactionForm(initialFormData);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   useEffect(() => {
     if (defaultValue) {
       setFormData({
@@ -91,13 +94,15 @@ export default function TransactionSubmitForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return; // 중복 제출 방지
 
     const errorMsg = validateFormData();
-
     if (errorMsg) {
       toast(errorMsg);
       return;
     }
+
+    setIsSubmitting(true);
     try {
       const {
         data: { user },
@@ -159,14 +164,17 @@ export default function TransactionSubmitForm({
       onClose();
     } catch (error) {
       toast.warning('수정 실패');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleDelete = async () => {
     if (!transaction) return;
+    if (isSubmitting) return;
 
     if (!confirm('삭제하시겠습니까?')) return;
-
+    setIsSubmitting(true);
     try {
       const { error } = await supabase
         .from('transactions')
@@ -183,6 +191,8 @@ export default function TransactionSubmitForm({
       onClose();
     } catch (error) {
       toast.error('오류가 발생했습니다');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -241,16 +251,13 @@ export default function TransactionSubmitForm({
               type="button"
               variant="outline"
               className="hover:text-destructive"
-              onClick={() => handleDelete()}
+              onClick={handleDelete}
             >
               <Trash className="h-4 w-4" />
             </Button>
           )}
-          <Button
-            type="submit"
-            className="flex-1"
-            onClick={(e) => handleSubmit(e)}
-          >
+          <Button type="submit" className="flex-1">
+            {isSubmitting && <Spinner />}
             {mode === 'create' ? '저장' : '수정'}
           </Button>
         </div>

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -161,7 +161,6 @@ export default function TransactionSubmitForm({
         tags: [],
       });
       onSuccess();
-      onClose();
     } catch (error) {
       toast.warning('수정 실패');
     } finally {
@@ -188,7 +187,6 @@ export default function TransactionSubmitForm({
 
       toast.success('기록이 삭제되었습니다');
       onSuccess();
-      onClose();
     } catch (error) {
       toast.error('오류가 발생했습니다');
     } finally {
@@ -252,11 +250,12 @@ export default function TransactionSubmitForm({
               variant="outline"
               className="hover:text-destructive"
               onClick={handleDelete}
+              disabled={isSubmitting}
             >
               <Trash className="h-4 w-4" />
             </Button>
           )}
-          <Button type="submit" className="flex-1">
+          <Button type="submit" className="flex-1" disabled={isSubmitting}>
             {isSubmitting && <Spinner />}
             {mode === 'create' ? '저장' : '수정'}
           </Button>

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -189,67 +189,71 @@ export default function TransactionSubmitForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="mx-auto flex h-full w-full flex-col space-y-6 p-10 pt-2"
+      className="mx-auto flex min-h-full w-full flex-1 flex-col px-10"
     >
-      <div className="bg-background sticky top-0 flex items-center justify-between border-b pb-4">
+      <div className="bg-background sticky top-0 z-10 flex items-center justify-between border-b pb-4">
         <Label className="text-xl">
           {mode === 'create' ? '가계부 작성' : '가계부 수정'}
         </Label>
       </div>
 
-      <TitleInput
-        value={formData.title}
-        onChange={(title) => UpdateField('title', title)}
-      />
-
-      <TypeSelector
-        value={formData.type}
-        onChange={(type) => {
-          UpdateField('type', type);
-          UpdateField('category_id', '');
-        }}
-      />
-
-      {formData.type !== '' && (
-        <CategorySelector
-          transactionType={formData.type}
-          value={formData.category_id}
-          open={categoryOpen}
-          onOpenChange={setCategoryOpen}
-          onChange={(category) => UpdateField('category_id', category)}
+      <div className="min-h-0 flex-1 space-y-6 py-6">
+        <TitleInput
+          value={formData.title}
+          onChange={(title) => UpdateField('title', title)}
         />
-      )}
 
-      <AmountInput
-        value={formData.amount}
-        onChange={(value) => UpdateField('amount', value)}
-      />
+        <TypeSelector
+          value={formData.type}
+          onChange={(type) => {
+            UpdateField('type', type);
+            UpdateField('category_id', '');
+          }}
+        />
 
-      <DatePicker
-        value={formData.date}
-        onChange={(date) => UpdateField('date', date)}
-      />
-
-      <TagInput tags={formData.tags} addTag={addTag} removeTag={removeTag} />
-
-      <div className="mt-auto flex gap-2 border-t p-4">
-        {mode === 'edit' && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleDelete()}
-            className="h-12 w-12"
-          >
-            <Trash />
-          </Button>
+        {formData.type !== '' && (
+          <CategorySelector
+            transactionType={formData.type}
+            value={formData.category_id}
+            open={categoryOpen}
+            onOpenChange={setCategoryOpen}
+            onChange={(category) => UpdateField('category_id', category)}
+          />
         )}
-        <Button
-          type="submit"
-          className="h-12 flex-1"
-          onClick={(e) => handleSubmit(e)}
-        >
-          {mode === 'create' ? '저장' : '수정'}
-        </Button>
+
+        <AmountInput
+          value={formData.amount}
+          onChange={(value) => UpdateField('amount', value)}
+        />
+
+        <DatePicker
+          value={formData.date}
+          onChange={(date) => UpdateField('date', date)}
+        />
+
+        <TagInput tags={formData.tags} addTag={addTag} removeTag={removeTag} />
+      </div>
+
+      <div className="bg-background sticky bottom-0 z-10 border-t py-4">
+        <div className="flex gap-2">
+          {mode === 'edit' && (
+            <Button
+              type="button"
+              variant="outline"
+              className="hover:text-destructive"
+              onClick={() => handleDelete()}
+            >
+              <Trash className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            type="submit"
+            className="flex-1"
+            onClick={(e) => handleSubmit(e)}
+          >
+            {mode === 'create' ? '저장' : '수정'}
+          </Button>
+        </div>
       </div>
     </form>
   );


### PR DESCRIPTION
## PR 개요
- 고정비 페이지 UI/UX를 거래 내역 페이지와 일관되게 개선하였습니다.
- 고정비/거래 추가·수정 폼에 공통 로딩 UX(버튼 비활성화·로딩 스피너)를 적용했습니다.
- 거래 저장/수정 시 목록 갱신 이전에 패널이 닫히던 타이밍 이슈를 함께 수정했습니다.

## 변경 사항
### 1. 고정비 페이지 레이아웃 및 UI 구조 개선
- 고정비 페이지 레이아웃을 거래 내역 페이지 구조와 통일
- 고정비 리스트 아이템을 분리하여 거래 리스트와 동일한 패턴으로 구성
- 고정비 추가/수정 폼 UI 정리 및 구조 개선
- 고정비 리스트 로딩 상태에 Skeleton UI 적용
### 2. 고정비 · 거래 폼 공통 UX 개선
- 고정비 / 거래 추가·수정 폼에 **저장·수정 버튼 로딩 스피너 표시**
- 로딩 중 버튼 비활성화 처리로 중복 요청 방지
- 패널 내부 **상단(타이틀) / 하단(액션 버튼) 고정 영역 + 콘텐츠 스크롤 구조 통일**
- 모바일/데스크탑 패널 환경에서 동일한 UX 흐름 유지
### 3. 거래 저장 후 패널 닫기 타이밍 이슈 수정
- 거래 저장 시 `router.refresh()` 이전에 패널이 닫히며 갱신 전 거래 목록이 다시 노출되던 문제 수정
- 패널 open/close 제어와 저장 성공 처리 로직을 분리하여 목록 갱신 이후 패널이 닫히도록 흐름 정리

## 스크린샷
| 고정비 페이지 UI | 고정비 폼 스크롤 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/bf7b36c7-c042-43f1-99d8-a75d2f7f4855" height="600" /> | <img src="https://github.com/user-attachments/assets/678d961b-41de-4913-82ce-72b2fd74c262" height="600" /> |

| 거래 폼 수정 before | 거래 폼 수정 After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/9ab43ca5-5a37-4b8a-85da-1c17a9fd6558" height="600" /> | <img src="https://github.com/user-attachments/assets/a9d7adfc-1900-4c73-a042-36207ec784c2" height="600" /> |


## 리뷰 요청 사항 
>- `components/panel/DrawerBottom.tsx` 23번째 줄에 `flex` 추가
>- `components/panel/SheetSide.tsx` 31번째 줄에 
`<div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">` 추가
>위 내용 추가 후 확인 부탁드려요!
- 고정비 패널 스크롤이 문제 없이 동작하는지 확인 부탁드립니다.
- 거래 저장 후 패널 닫기 타이밍을 목록 갱신 이후로 조정한 흐름이 괜찮은지 확인 부탁드립니다.
  > 저장/수정 성공 시 setFormData 초기화로직이 존재해서 리셋된 폼이 보여지는데 제가 건들이기엔 범위가 커질 것 같아 이 부분은 따로 건들지 않았습니다.