### PR TITLE
[fix] 예산 템플릿 적용 시 Step2 금액 초기화 및 이전 버튼 비활성화 완료

### DIFF
--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -240,6 +240,7 @@ const BudgetRecommendDialog = ({
                   variant="outline"
                   className="h-12 flex-1 cursor-pointer text-base font-bold"
                   onClick={() => setStep(step - 1)}
+                  disabled={isSubmitting}
                 >
                   이전
                 </Button>

--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -67,7 +67,7 @@ const BudgetRecommendDialog = ({
     }
   }, [processedData]); // processedData가 로드되는 순간 실행됨
 
-  // open 상태가 false가 될 때 step을 1로 리셋
+  // 다이얼로그가 닫힐 때 상태 리셋
   useEffect(() => {
     if (!open) {
       const timer = setTimeout(() => {
@@ -75,6 +75,12 @@ const BudgetRecommendDialog = ({
         setSelectedTemplateId('keep-pattern');
         setBudgetDraft([]);
         setIsAdjusted(false);
+
+        setGoalData({
+          income: 0,
+          savingsAmount: 0,
+        });
+        setConfirmedSavings(0);
       }, 300);
       return () => clearTimeout(timer);
     }

--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -189,7 +189,13 @@ const BudgetRecommendDialog = ({
   const spendableBudget = goalData.income - goalData.savingsAmount;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (isSubmitting) return; // 저장 중 닫기 방지
+        onOpenChange(isOpen);
+      }}
+    >
       <DialogContent className="flex h-[800px] w-full flex-col md:max-w-2xl">
         {/* 상단 Step 표시 */}
         <div className="px-6 pt-6">


### PR DESCRIPTION
## PR 개요
- 템플릿 재진입 시 이전 데이터가 남는 버그를 수정하고, 예산 저장 중 발생할 수 있는 이탈 경로를 방지하는 로직을 추가했습니다.

## 변경 사항
- 다이얼로그 재진입 시 Step2 예산 설정 데이터 초기화 로직 추가
  - 다이얼로그가 닫힐 때 상태를 리셋하여 재진입 시 항상 가이드 금액(`20%`)이 초기값으로 들어가도록 수정
- 예산 저장 중, 이전 버튼 비활성화 처리
- 저장 중 다이얼로그 닫힘 방지 (배경 클릭 및 esc로 인한 닫힘)

## 리뷰 요청 사항
- 아래 내용 확인 부탁드립니다!
  - 템플릿으로 예산 설정할 때, 재진입 시, 금액이 이전 설정과 달리 초기화 되는지
  - 예산 저장 중 이전 버튼, 배경 클릭, esc 같은 동작이 막혀있는지