### PR TITLE
[fix] 소형 모바일 화면에서의 캘린더 컴포넌트 반응형 디자인 문제

### DIFF
--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -51,6 +51,7 @@ export default async function Home({ searchParams }: PageProps) {
               selectedDate={params.selected_date}
               monthDate={monthDate}
             />
+            {/* <CalendarSkeleton /> */}
           </Suspense>
         </CalendarProvider>
       </TransactionProvider>

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -286,6 +286,7 @@ export const Calendar = ({
           {panelState.view === 'edit' && (
             <div className="space-y-2">
               <Button
+                variant={'ghost'}
                 onClick={() => {
                   setPanelState({ view: 'list' });
                 }}

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -240,7 +240,7 @@ export const Calendar = ({
         onMonthChange={handleMonthChange}
         onDayClick={(day) => open(day)}
         className={cn(
-          'w-full rounded-md border shadow-sm',
+          'w-full rounded-md border border-none shadow-sm',
           '[&_.rdp-caption]:!hidden [&_.rdp-nav]:hidden',
           '[&_.rdp-month]:w-full [&_.rdp-table]:w-full [&_td]:p-0',
           CALENDAR_CELL_HEIGHT

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -36,7 +36,8 @@ interface PanelState {
 }
 
 const CALENDAR_CELL_HEIGHT =
-  '[&_td]:!h-[60px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
+  '[&_td]:!h-[50px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
+
 const CustomDay = ({
   day,
   modifiers,
@@ -56,19 +57,20 @@ const CustomDay = ({
       data-selected-single={modifiers.selected}
       {...props}
       className={cn(
-        'flex flex-col items-center justify-start gap-1 p-2 pt-1',
-        'aspect-square w-full',
-        'h-full w-full',
+        'flex flex-col items-center justify-start gap-1',
+        'aspect-square h-full w-full',
+        'p-0.5 sm:p-2 sm:pt-1',
+        'gap-0 sm:gap-1',
         CALENDAR_CELL_HEIGHT,
         defaultClassNames.day
       )}
     >
-      <div className="flex flex-col gap-0.5 sm:gap-1 md:gap-2">
+      <div className="flex flex-col gap-0.5 sm:gap-0.5 md:gap-1">
         <span className="text-sm font-medium sm:text-base md:text-lg">
           {day.date.getDate()}
         </span>
         {dayData && (dayData.income > 0 || dayData.expense > 0) && (
-          <div className="flex flex-col text-[8px] sm:text-[10px] md:text-xs">
+          <div className="flex flex-col text-[7px] sm:text-[10px] md:text-xs">
             {dayData.income > 0 && (
               <span className="text-blue-500">
                 +{dayData.income.toLocaleString()}

--- a/fe/src/components/calendar/CalendarSkeleton.tsx
+++ b/fe/src/components/calendar/CalendarSkeleton.tsx
@@ -4,9 +4,6 @@ import { DailyRecBarSkeleton } from '../daily-recommendation/DailyRecBarSkeleton
 export function CalendarSkeleton() {
   return (
     <div className="flex w-full flex-col items-center">
-      <div className="w-full">
-        <DailyRecBarSkeleton />
-      </div>
       <div className="flex flex-col items-center justify-center py-6 md:py-10">
         <Skeleton className="mb-2 h-4 w-12" />
         <div className="flex items-center gap-3">
@@ -15,11 +12,14 @@ export function CalendarSkeleton() {
           <Skeleton className="h-10 w-10 rounded-md" />
         </div>
       </div>
-
+      <div className="w-full">
+        <DailyRecBarSkeleton />
+      </div>
       <div className="flex w-full gap-2 p-2 sm:gap-4">
         <Skeleton className="h-16 w-full rounded-xl" />
         <Skeleton className="h-16 w-full rounded-xl" />
       </div>
+
       <div className="w-full rounded-md border p-2">
         <div className="mb-2 grid grid-cols-7 gap-1">
           {Array.from({ length: 7 }).map((_, i) => (


### PR DESCRIPTION
## PR 개요
- 모바일 화면에서 캘린더 cell이 캘린더 밖으로 나가는 이슈

## 변경 사항
- cell 높이 재조정
- 패딩값 축소
- 텍스트 크기 축소
- calendar border 삭제

## 리뷰 요청 사항
- 소형 모바일 화면 (너비 400px 이하)에서 캘린더가 정상적으로 표시되는지
- 캘린더 cell을 눌렀을 때 열리는 panel 내부가 밀림 없이 잘 표시되는지