### PR TITLE
[fix] 게스트 모드 분석 페이지 진입 시 데이터 로딩 실패 및 에러 발생 문제

### DIFF
--- a/fe/src/hooks/useAnalysisData.ts
+++ b/fe/src/hooks/useAnalysisData.ts
@@ -21,6 +21,14 @@ type CategoryGroup = {
   [key: string]: number;
 };
 
+const safeSyncTransactions = async (date: Date, through: string) => {
+  try {
+    await syncByMonthClient(date, through);
+  } catch (err) {
+    console.warn(`${date.getMonth() + 1}월 고정비 동기화 실패:`, err);
+  }
+};
+
 export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
   const [data, setData] = useState<AnalysisState>({
     current: [],
@@ -52,8 +60,8 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
         const lastMonthThrough = minDate(prevEnd, today);
 
         await Promise.all([
-          syncByMonthClient(selectedDate, today), // 현재 달 : 오늘까지 생성
-          syncByMonthClient(lastMonthDate, lastMonthThrough), // 이전 달 : 오늘(or 월말)까지 생성
+          safeSyncTransactions(selectedDate, today), // 현재 달 : 오늘까지 생성
+          safeSyncTransactions(lastMonthDate, lastMonthThrough), // 이전 달 : 오늘(or 월말)까지 생성
         ]);
 
         // 서비스 함수 호출


### PR DESCRIPTION
## PR 개요
- 고정비 동기화 실패로 인해 분석(거래 조회) 화면이 표시되지 않던 문제를 해결했습니다.

## 변경 사항
- 고정비 동기화 로직을 safeSyncTransactions 함수로 분리
  - 동기화 실패 시 에러를 내부에서 처리하고 조회 로직에는 영향을 주지 않도록 처리
  - 에러 발생 시 `console.warn`으로만 처리

## 스크린샷 (선택)
| 변경 전 | 변경 후 |
|------------|------------|
| <img width="1050" height="985" alt="image" src="https://github.com/user-attachments/assets/7fa9d031-9827-4224-8310-07ae1d41a324" /> | <img width="937" height="987" alt="image" src="https://github.com/user-attachments/assets/704691ce-664c-4fa1-b117-1d11f678c6e0" /> |

## 리뷰 요청 사항
고정비 동기화 과정에서 에러가 발생해도 거래 내역 조회가 되도록 수정했습니다.
- 게스트 모드 시, 분석 화면 지출/수입 탭에서 정보가 제대로 나오는지 확인 부탁드립니다.