### PR TITLE
[fix] 모바일 환경 카테고리 예산 입력 UI 잘림 문제

### DIFF
--- a/fe/src/components/budgets/BudgetCategorySetting.tsx
+++ b/fe/src/components/budgets/BudgetCategorySetting.tsx
@@ -160,16 +160,14 @@ const BudgetCategorySetting = ({
       </div>
 
       {/* 하단 버튼 영역 */}
-      <div className="bg-background sticky bottom-0 space-y-2 border-t pt-2 pb-4">
+      <div className="bg-background sticky bottom-0 space-y-2 border-t pt-2 pb-4 text-xs md:text-sm">
         {isOverBudget ? (
-          <p
-            className={cn('text-center text-sm font-bold', THEME_COLOR.EXPENSE)}
-          >
+          <p className={cn('text-center font-bold', THEME_COLOR.EXPENSE)}>
             총 예산을 늘리거나 카테고리 금액을 조절해주세요.
           </p>
         ) : (
           !isDirty && (
-            <p className="text-muted-foreground text-center text-xs md:text-sm">
+            <p className="text-muted-foreground text-center">
               {categoryBudgets.length === 0
                 ? '카테고리별 예산 금액을 입력해주세요.'
                 : '기존에 설정된 금액과 동일합니다.'}
@@ -179,7 +177,7 @@ const BudgetCategorySetting = ({
 
         <Button
           className={cn(
-            'h-10 w-full cursor-pointer text-xs md:h-12 md:text-sm',
+            'h-10 w-full cursor-pointer md:h-12',
             isOverBudget && 'bg-red-400 hover:bg-red-500'
           )}
           onClick={handleSave}

--- a/fe/src/components/budgets/BudgetCategorySetting.tsx
+++ b/fe/src/components/budgets/BudgetCategorySetting.tsx
@@ -3,8 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 import BudgetCategoryEditItem from '@/components/budgets/common/BudgetCategoryEditItem';
 import BudgetSummary from '@/components/budgets/common/BudgetSummary';
 import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Separator } from '@/components/ui/separator';
 import { THEME_COLOR } from '@/constants/colors';
 import { cn } from '@/lib/utils';
 import useBudgetData from '@/hooks/useBudgetData';
@@ -92,8 +90,7 @@ const BudgetCategorySetting = ({
       if (!targetInput) return;
 
       targetInput.focus();
-      targetInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, 100);
+    }, 200);
 
     return () => clearTimeout(timer);
   }, [initialCategoryKey, isCategoriesLoading]);
@@ -128,48 +125,42 @@ const BudgetCategorySetting = ({
 
   return (
     <div className="flex h-full flex-col px-8">
-      <div className="bg-background sticky top-0 space-y-1 pb-4">
-        <p className="text-xl font-bold">카테고리별 예산 설정</p>
-        <p className="text-muted-foreground text-sm font-medium">
+      <div className="bg-background sticky top-0 z-10 space-y-1 border-b pb-4">
+        <p className="text-lg font-bold md:text-xl">카테고리별 예산 설정</p>
+        <p className="text-muted-foreground text-xs font-medium md:text-sm">
           항목별 목표 금액을 정해보세요.
         </p>
+      </div>
 
+      {/* 카테고리 예산 설정 */}
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 py-2">
         <BudgetSummary
           totalBudget={totalBudgetAmount}
           totalAllocated={totalAllocated}
           onEditTotal={onEditTotalBudget}
         />
+
+        {isCategoriesLoading ? (
+          <div>카테고리 목록 불러오는 중</div>
+        ) : (
+          allCategories?.map((category) => (
+            <BudgetCategoryEditItem
+              key={category.category_key}
+              category={category}
+              amount={amounts[category.category_key] ?? ''}
+              totalBudgetAmount={totalBudgetAmount}
+              onChange={handleAmountChange}
+              onReset={handleResetCategory}
+              inputRef={(el) => {
+                inputRefs.current[category.category_key] = el;
+              }}
+            />
+          ))
+        )}
       </div>
 
-      <Separator />
-
-      {/* 카테고리 예산 설정 */}
-      <ScrollArea className="flex-1 overflow-y-auto">
-        <div className="flex flex-col gap-5 px-2 py-4">
-          {isCategoriesLoading ? (
-            <div>카테고리 목록 불러오는 중</div>
-          ) : (
-            allCategories?.map((category) => (
-              <BudgetCategoryEditItem
-                key={category.category_key}
-                category={category}
-                amount={amounts[category.category_key] ?? ''}
-                totalBudgetAmount={totalBudgetAmount}
-                onChange={handleAmountChange}
-                onReset={handleResetCategory}
-                inputRef={(el) => {
-                  inputRefs.current[category.category_key] = el;
-                }}
-              />
-            ))
-          )}
-        </div>
-      </ScrollArea>
-
-      <Separator />
-
       {/* 하단 버튼 영역 */}
-      <div className="bg-background sticky bottom-0 space-y-4 border-t p-4">
+      <div className="bg-background sticky bottom-0 space-y-2 border-t pt-2 pb-4">
         {isOverBudget ? (
           <p
             className={cn('text-center text-sm font-bold', THEME_COLOR.EXPENSE)}
@@ -178,7 +169,7 @@ const BudgetCategorySetting = ({
           </p>
         ) : (
           !isDirty && (
-            <p className="text-muted-foreground text-center text-sm">
+            <p className="text-muted-foreground text-center text-xs md:text-sm">
               {categoryBudgets.length === 0
                 ? '카테고리별 예산 금액을 입력해주세요.'
                 : '기존에 설정된 금액과 동일합니다.'}
@@ -188,7 +179,7 @@ const BudgetCategorySetting = ({
 
         <Button
           className={cn(
-            'h-12 w-full cursor-pointer text-base',
+            'h-10 w-full cursor-pointer text-xs md:h-12 md:text-sm',
             isOverBudget && 'bg-red-400 hover:bg-red-500'
           )}
           onClick={handleSave}

--- a/fe/src/components/budgets/BudgetView.tsx
+++ b/fe/src/components/budgets/BudgetView.tsx
@@ -170,6 +170,7 @@ const BudgetView = ({ selectedDate }: { selectedDate: Date }) => {
           setIsCategoryPanelOpen(open);
           if (!open) setActiveCategoryKey(null);
         }}
+        isFull
       >
         <BudgetCategorySetting
           selectedDate={selectedDate}

--- a/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
+++ b/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
@@ -51,7 +51,7 @@ const BudgetCategoryEditItem = ({
 
       {/* 카테고리명 */}
       <div className="flex flex-1 items-center gap-1">
-        <p className="text-sm font-semibold">{category.name_ko}</p>
+        <p className="text-xs font-semibold md:text-sm">{category.name_ko}</p>
         {percent > 0 && (
           <Badge
             className={cn(
@@ -85,7 +85,7 @@ const BudgetCategoryEditItem = ({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           onChange={(e) => onChange(category.category_key, e.target.value)}
-          className="focus-visible:ring-brand-soft h-9 pr-7 text-right"
+          className="focus-visible:ring-brand-soft h-9 pr-7 text-right text-sm"
         />
         {amount && (
           <Button

--- a/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
+++ b/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
@@ -73,6 +73,7 @@ const BudgetCategoryEditItem = ({
         <Input
           ref={inputRef}
           type="text"
+          inputMode="numeric"
           placeholder="0"
           value={
             isFocused

--- a/fe/src/components/budgets/common/BudgetSummary.tsx
+++ b/fe/src/components/budgets/common/BudgetSummary.tsx
@@ -22,19 +22,19 @@ const BudgetSummary = ({
   return (
     <Card
       className={cn(
-        'mt-2 gap-0 p-5 transition-all',
+        'my-2 gap-2 p-5 transition-all',
         isOverBudget ? 'bg-destructive/5' : 'bg-primary-foreground'
       )}
     >
-      <div className="mb-4 flex items-end justify-between">
+      <div className="flex flex-col items-start gap-2 md:flex-row md:items-end md:justify-between">
         <div className="space-y-1">
           <p className="text-sm font-bold">총 예산</p>
 
           <div className="flex items-center gap-2 tracking-tight">
-            <span className="text-2xl font-bold">
+            <span className="font-bold md:text-lg">
               {totalAllocated.toLocaleString()}
             </span>
-            <div className="text-muted-foreground flex items-center text-sm">
+            <div className="text-muted-foreground flex items-center text-xs md:text-sm">
               /
               <div
                 className="hover:text-primary flex cursor-pointer items-center gap-1 rounded-lg px-2 py-1 transition-colors hover:underline"
@@ -47,18 +47,18 @@ const BudgetSummary = ({
           </div>
         </div>
 
-        <div className="text-right">
+        <div className="md:text-right">
           <p className="text-muted-foreground text-xs font-medium">남은 예산</p>
           <p
             className={cn(
-              'text-lg font-bold tracking-tight',
+              'font-bold tracking-tight md:text-lg',
               isOverBudget ? THEME_COLOR.EXPENSE : 'text-brand'
             )}
           >
             {isOverBudget
               ? `-${Math.abs(remaining).toLocaleString()}`
               : remaining.toLocaleString()}
-            원
+            <span className="text-sm">원</span>
           </p>
         </div>
       </div>
@@ -72,7 +72,12 @@ const BudgetSummary = ({
         />
 
         {isOverBudget && (
-          <p className={cn('mt-2 text-sm font-medium', THEME_COLOR.EXPENSE)}>
+          <p
+            className={cn(
+              'mt-2 text-xs font-medium md:text-sm',
+              THEME_COLOR.EXPENSE
+            )}
+          >
             ⚠️ 설정된 카테고리 예산이 총 예산을 초과했습니다.
           </p>
         )}

--- a/fe/src/components/budgets/common/BudgetSummary.tsx
+++ b/fe/src/components/budgets/common/BudgetSummary.tsx
@@ -22,7 +22,7 @@ const BudgetSummary = ({
   return (
     <Card
       className={cn(
-        'mt-4 gap-0 p-5 transition-all',
+        'mt-2 gap-0 p-5 transition-all',
         isOverBudget ? 'bg-destructive/5' : 'bg-primary-foreground'
       )}
     >


### PR DESCRIPTION
## PR 개요
- 모바일 환경에서 카테고리별 예산 금액 입력 시,  키패드 노출로 인해 입력 영역이 가려지던 UI 문제를 개선했습니다.

## 변경 사항
- `BudgetSummary`를 스크롤 영역 내부로 이동
- 바텀 시트를 전체 화면(`isFull`)으로 사용하도록 레이아웃 조정
- 금액 입력 input에 `inputMode="numeric"` 적용하여 숫자 키패드가 노출되도록 개선
- 모바일 화면 기준 텍스트 크기 및 간격 조정

## 스크린샷 (선택)
| 변경 전 | 변경 후 |
|------------|------------|
| <img width="850" height="1500" alt="image" src="https://github.com/user-attachments/assets/c1c52d46-0db1-4c42-b8cd-36faacd3d74b" /> | ![BudgetCategorySetting_mobile](https://github.com/user-attachments/assets/efacf736-887b-4a03-b080-f4e1c6f2ad27) |


## 리뷰 요청 사항
- 실제 모바일 기기에서의 확인이 어려울 수 있어, 동작은 첨부한 스크린샷 기준으로 리뷰 부탁드립니다.
- 아래 내용 확인 부탁드립니다.
  - 바텀 시트가 전체 화면으로 잘 나오는지
  - 예산 설정 현황(`BudgetSummary`)이 스크롤 내부에 잘 위치해 있는지