### PR TITLE
[refactor] 인증 · 사용자 상태 전역 관리 개선

### DIFF
--- a/fe/src/app/(app)/history/actions.ts
+++ b/fe/src/app/(app)/history/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 import { syncByMonthServer } from '@/services/fixed-costs/syncFixedTransactions.server';
 import { formatLocalDate } from '@/utils/date';
-import { createClient } from '@/utils/supabase/server';
+import { requireUserServer } from '@/utils/supabase/requireUserServer';
 import { revalidatePath } from 'next/cache';
 
 export interface TransactionFilters {
@@ -16,13 +16,7 @@ export const getTransaction = async (
   filters?: TransactionFilters,
   defaultMonth: boolean = true
 ) => {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) throw new Error('No User');
+  const { supabase, user } = await requireUserServer();
 
   let startDate = filters?.start_date;
   let endDate = filters?.end_date;

--- a/fe/src/app/(auth)/login/page.tsx
+++ b/fe/src/app/(auth)/login/page.tsx
@@ -3,7 +3,6 @@
 import AnimatedLogo from '@/components/login/AnimatedLogo';
 import { Spinner } from '@/components/ui/spinner';
 import { supabase } from '@/utils/supabase/client';
-import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -14,7 +13,6 @@ type LoadingAction = 'google' | 'kakao' | 'guest' | null;
 
 export default function LoginPage() {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const [loadingAction, setLoadingAction] = useState<LoadingAction>(null);
   const isLoading = loadingAction !== null;
 
@@ -67,8 +65,6 @@ export default function LoginPage() {
         setLoadingAction(null);
         return;
       }
-
-      queryClient.removeQueries({ queryKey: ['profile'] });
 
       router.replace('/');
       router.refresh();

--- a/fe/src/app/provider.tsx
+++ b/fe/src/app/provider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AuthProvider } from '@/providers/AuthProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -26,7 +27,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         enableSystem
         disableTransitionOnChange // 테마 변경 시 스타일 깜빡임 방지
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </ThemeProvider>
     </QueryClientProvider>

--- a/fe/src/components/common/ProfilePanelTrigger.tsx
+++ b/fe/src/components/common/ProfilePanelTrigger.tsx
@@ -4,22 +4,12 @@ import MyInfo from '@/components/my-info/MyInfo';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import ResponsivePanel from '../panel/ResponsivePanel';
-import { useQuery } from '@tanstack/react-query';
-import { Profile } from '@/schemas/profile';
 import Image from 'next/image';
-
-async function fetchProfile(): Promise<Profile> {
-  const res = await fetch('/api/profile', { method: 'GET' });
-  if (!res.ok) throw new Error('프로필 조회 실패');
-  return res.json();
-}
+import { useAuth } from '@/providers/AuthProvider';
 
 export default function ProfilePanelTrigger() {
-  const { data: profile } = useQuery({
-    queryKey: ['profile'],
-    queryFn: fetchProfile,
-    retry: false,
-  });
+  const { profile } = useAuth();
+
   return (
     <ResponsivePanel
       trigger={

--- a/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
+++ b/fe/src/components/fixed-costs/FixedCostSubmitForm.tsx
@@ -20,6 +20,7 @@ import { useState } from 'react';
 import FixedCostEditConfirmDialog from './FixedCostEditConfirmDialog';
 import FixedCostDeleteDialog from './FixedCostDeleteDialog';
 import { Spinner } from '../ui/spinner';
+import { useAuth } from '@/providers/AuthProvider';
 
 type FixedCostSubmitFormProps = {
   mode: 'create' | 'edit';
@@ -34,6 +35,8 @@ export default function FixedCostSubmitForm({
   ruleId,
   onSuccess,
 }: FixedCostSubmitFormProps) {
+  const { userId, isLoading: authLoading } = useAuth();
+
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingPayload, setPendingPayload] =
     useState<CreateFixedRuleInput | null>(null);
@@ -57,6 +60,9 @@ export default function FixedCostSubmitForm({
       return;
     }
 
+    if (authLoading) return;
+    if (!userId) return;
+
     const payload: CreateFixedRuleInput = {
       title: formData.title.trim(),
       type: formData.type as 'income' | 'expense',
@@ -79,7 +85,7 @@ export default function FixedCostSubmitForm({
     setIsSubmitting(true);
 
     try {
-      await createFixedRule(payload);
+      await createFixedRule(userId, payload);
       toast.success('고정비가 추가되었습니다.');
       onSuccess(); // 고정비 목록 갱신
     } catch {
@@ -97,10 +103,13 @@ export default function FixedCostSubmitForm({
   const handleApplyIncludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
     if (isSubmitting) return;
+    if (authLoading) return;
+    if (!userId) return;
 
     setIsSubmitting(true);
     try {
       await updateFixedRuleWithScope({
+        userId,
         id: ruleId,
         ruleInput: pendingPayload,
         scope: 'INCLUDE_CURRENT',
@@ -119,10 +128,13 @@ export default function FixedCostSubmitForm({
   const handleApplyExcludeCurrent = async () => {
     if (!ruleId || !pendingPayload) return;
     if (isSubmitting) return;
+    if (authLoading) return;
+    if (!userId) return;
 
     setIsSubmitting(true);
     try {
       await updateFixedRuleWithScope({
+        userId,
         id: ruleId,
         ruleInput: pendingPayload,
         scope: 'EXCLUDE_CURRENT',
@@ -141,10 +153,12 @@ export default function FixedCostSubmitForm({
   const handleDeleteRule = async () => {
     if (!ruleId) return;
     if (isSubmitting) return;
+    if (authLoading) return;
+    if (!userId) return;
 
     setIsSubmitting(true);
     try {
-      await deleteFixedRule(ruleId);
+      await deleteFixedRule(userId, ruleId);
       toast.success('고정비 규칙이 삭제되었습니다.');
       onSuccess();
     } catch {

--- a/fe/src/components/fixed-costs/FixedCostsPage.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsPage.tsx
@@ -9,18 +9,20 @@ import { IFixedRule } from '@/types/fixed-costs';
 import { fetchFixedRules } from '@/services/fixed-costs/fixed-costs';
 import { toast } from 'sonner';
 import { mapFixedRuleToFormData } from '@/utils/fixed-costs';
+import { useAuth } from '@/providers/AuthProvider';
 
 export default function FixedCostsPage() {
+  const { userId, isLoading: authLoading } = useAuth();
   const [items, setItems] = useState<IFixedRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
   const [editingRule, setEditingRule] = useState<IFixedRule | null>(null);
 
-  const fetchData = async () => {
+  const fetchData = async (userId: string) => {
     try {
       setIsLoading(true);
-      const data = await fetchFixedRules();
+      const data = await fetchFixedRules(userId);
       setItems(data);
     } catch {
       toast.error(
@@ -32,8 +34,10 @@ export default function FixedCostsPage() {
   };
 
   useEffect(() => {
-    fetchData();
-  }, []);
+    if (authLoading) return;
+    if (!userId) return;
+    fetchData(userId);
+  }, [authLoading, userId]);
 
   const handleCreateClick = () => {
     setFormMode('create');
@@ -42,7 +46,8 @@ export default function FixedCostsPage() {
   };
 
   const handleCreateSuccess = async () => {
-    await fetchData();
+    if (!userId) return;
+    await fetchData(userId);
     setIsPanelOpen(false);
   };
 

--- a/fe/src/components/layout/Header.tsx
+++ b/fe/src/components/layout/Header.tsx
@@ -3,24 +3,15 @@
 import GuestModeNotice from '../common/GuestModeNotice';
 import Image from 'next/image';
 import Link from 'next/link';
-import ModeToggle from '../common/ModeToggle';
-import { Profile } from '@/schemas/profile';
 import ProfilePanelTrigger from '../common/ProfilePanelTrigger';
-import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/providers/AuthProvider';
 
-async function fetchProfile(): Promise<Profile> {
-  const res = await fetch('/api/profile');
-  if (!res.ok) throw new Error('프로필 조회 실패');
-  return res.json();
+function HeaderRightSkeleton() {
+  return <div className="bg-muted h-9 w-9 animate-pulse rounded-full" />;
 }
 
 const Header = () => {
-  const { data: profile } = useQuery({
-    queryKey: ['profile'],
-    queryFn: fetchProfile,
-    retry: false,
-  });
-
+  const { profile, isLoading } = useAuth();
   const isGuest = !!profile?.is_guest;
 
   return (
@@ -38,7 +29,13 @@ const Header = () => {
           />
         </Link>
       </h1>
-      {isGuest ? <GuestModeNotice /> : <ProfilePanelTrigger />}
+      {isLoading ? (
+        <HeaderRightSkeleton />
+      ) : isGuest ? (
+        <GuestModeNotice />
+      ) : (
+        <ProfilePanelTrigger />
+      )}
     </header>
   );
 };

--- a/fe/src/components/my-info/LogoutButton.tsx
+++ b/fe/src/components/my-info/LogoutButton.tsx
@@ -3,16 +3,13 @@
 import { supabase } from '@/utils/supabase/client';
 import { useRouter } from 'next/navigation';
 import { Button } from '../ui/button';
-import { useQueryClient } from '@tanstack/react-query';
 
 export default function LogoutButton() {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
 
-    queryClient.removeQueries({ queryKey: ['profile'] });
     router.replace('/login'); // 로그아웃 후 로그인 페이지로 리다이렉트
     router.refresh();
   };

--- a/fe/src/components/my-info/MyInfo.tsx
+++ b/fe/src/components/my-info/MyInfo.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { Profile, ProfilePatchValues } from '@/schemas/profile';
 import { Separator } from '@/components/ui/separator';
@@ -11,13 +11,7 @@ import ProfileView from './ProfileView';
 import MyInfoSkeleton from './MyInfoSkeleton';
 import { toast } from 'sonner';
 import ModeToggle from '../common/ModeToggle';
-
-// 프로필 조회 함수
-async function fetchProfile(): Promise<Profile> {
-  const res = await fetch('/api/profile', { method: 'GET' });
-  if (!res.ok) throw new Error('프로필 조회 실패');
-  return res.json();
-}
+import { useAuth } from '@/providers/AuthProvider';
 
 // 프로필 수정 함수
 async function updateProfile(values: ProfilePatchValues): Promise<Profile> {
@@ -33,25 +27,13 @@ async function updateProfile(values: ProfilePatchValues): Promise<Profile> {
 
 export default function MyInfo() {
   const [isEditing, setIsEditing] = useState(false);
-
-  // 프로필 데이터 조회
-  const {
-    data: profile,
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: ['profile'],
-    queryFn: fetchProfile,
-    retry: false,
-  });
-
-  const queryClient = useQueryClient();
+  const { profile, isLoading, error, setProfile } = useAuth();
 
   // 프로필 수정 뮤테이션
   const { mutateAsync } = useMutation({
     mutationFn: updateProfile,
     onSuccess: (updated) => {
-      queryClient.setQueryData(['profile'], updated);
+      setProfile(updated);
       toast.success('프로필이 저장되었어요.');
     },
     onError: () => {
@@ -69,7 +51,7 @@ export default function MyInfo() {
     return <MyInfoSkeleton />;
   }
 
-  if (isError || !profile) {
+  if (error || !profile) {
     return (
       <div className="p-4 text-sm text-red-500">
         프로필을 불러오지 못했습니다.

--- a/fe/src/components/transaction/ReceiptMulti.tsx
+++ b/fe/src/components/transaction/ReceiptMulti.tsx
@@ -25,6 +25,7 @@ import {
 } from '../ui/dialog';
 import { Progress } from '@/components/ui/progress';
 import { Label } from '../ui/label';
+import { useAuth } from '@/providers/AuthProvider';
 
 interface ResultWithPreview {
   result: OCRResult;
@@ -32,6 +33,8 @@ interface ResultWithPreview {
 }
 
 export default function ReceiptMulti() {
+  const { userId, isLoading: authLoading } = useAuth();
+
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
@@ -161,23 +164,15 @@ export default function ReceiptMulti() {
       return;
     }
 
+    if (authLoading) return;
+    if (!userId) return;
+    setLoading(true);
+
     try {
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
-
-      if (!user || authError) {
-        toast.warning('로그인이 필요합니다');
-        return;
-      }
-
-      setLoading(true);
-
       const transactionsData = results
         .filter((_, index) => checkedItems.has(index))
         .map((item) => ({
-          user_id: user.id,
+          user_id: userId,
           title: item.result.title,
           type: 'expense',
           amount: Number(item.result.amount),

--- a/fe/src/components/transaction/TransactionSubmitForm.tsx
+++ b/fe/src/components/transaction/TransactionSubmitForm.tsx
@@ -15,6 +15,7 @@ import { TypeSelector } from './common/TypeSelector';
 import { CategorySelector } from './common/CategorySelector';
 import { QuickAmountButtons } from './common/QuickAmountButtons';
 import { Spinner } from '../ui/spinner';
+import { useAuth } from '@/providers/AuthProvider';
 
 interface TransactionsSubmitFormProps {
   mode: 'create' | 'edit';
@@ -66,6 +67,8 @@ export default function TransactionSubmitForm({
     }
   }, [mode, transaction, defaultDate, defaultValue]);
 
+  const { userId, isLoading: authLoading } = useAuth();
+
   const {
     formData,
     setFormData,
@@ -102,23 +105,18 @@ export default function TransactionSubmitForm({
       return;
     }
 
+    if (authLoading) return;
+    if (!userId) return;
+
     setIsSubmitting(true);
     try {
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
-      if (!user || authError) {
-        toast.warning('로그인이 필요합니다');
-        return;
-      }
       const year = formData.date.getFullYear();
       const month = String(formData.date.getMonth() + 1).padStart(2, '0');
       const day = String(formData.date.getDate()).padStart(2, '0');
       const formattedDate = `${year}-${month}-${day}`;
 
       const transactionData = {
-        user_id: user.id,
+        user_id: userId,
         title: formData.title.trim(),
         type: formData.type,
         amount: Number(formData.amount),

--- a/fe/src/hooks/useAnalysisData.ts
+++ b/fe/src/hooks/useAnalysisData.ts
@@ -7,9 +7,9 @@ import { formatLocalDate, getMonthRange, minDate } from '@/utils/date';
 import { useEffect, useMemo, useState } from 'react';
 
 import { fetchTransactionByRange } from '@/services/analysis/analysisService';
-import { getCurrentUser } from '@/services/analysis/budgetService';
 import { syncByMonthClient } from '@/services/fixed-costs/syncFixedTransactions.client';
 import { toast } from 'sonner';
+import { useAuth } from '@/providers/AuthProvider';
 
 type AnalysisState = {
   current: TransactionAnalysis[];
@@ -21,15 +21,21 @@ type CategoryGroup = {
   [key: string]: number;
 };
 
-const safeSyncTransactions = async (date: Date, through: string) => {
+const safeSyncTransactions = async (
+  userId: string,
+  date: Date,
+  through: string
+) => {
   try {
-    await syncByMonthClient(date, through);
+    await syncByMonthClient(userId, date, through);
   } catch (err) {
     console.warn(`${date.getMonth() + 1}월 고정비 동기화 실패:`, err);
   }
 };
 
 export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
+  const { userId, isLoading: authLoading } = useAuth();
+
   const [data, setData] = useState<AnalysisState>({
     current: [],
     prev: [],
@@ -40,10 +46,11 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
 
   useEffect(() => {
     const fetchData = async () => {
+      if (authLoading) return;
+      if (!userId) return;
+
       try {
         setIsLoading(true);
-
-        const user = await getCurrentUser(); // 현재 로그인한 유저 정보 가져오기
 
         // 날짜 범위 계산
         const { startDate, endDate } = getMonthRange(selectedDate);
@@ -60,14 +67,14 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
         const lastMonthThrough = minDate(prevEnd, today);
 
         await Promise.all([
-          safeSyncTransactions(selectedDate, today), // 현재 달 : 오늘까지 생성
-          safeSyncTransactions(lastMonthDate, lastMonthThrough), // 이전 달 : 오늘(or 월말)까지 생성
+          safeSyncTransactions(userId, selectedDate, today), // 현재 달 : 오늘까지 생성
+          safeSyncTransactions(userId, lastMonthDate, lastMonthThrough), // 이전 달 : 오늘(or 월말)까지 생성
         ]);
 
         // 서비스 함수 호출
         const [currentMonthRes, prevMonthRes] = await Promise.all([
-          fetchTransactionByRange(user.id, type, startDate, endDate),
-          fetchTransactionByRange(user.id, type, prevStart, prevEnd),
+          fetchTransactionByRange(userId, type, startDate, endDate),
+          fetchTransactionByRange(userId, type, prevStart, prevEnd),
         ]);
 
         setData({
@@ -88,7 +95,7 @@ export const useAnalysisData = (selectedDate: Date, type: TransactionType) => {
     };
 
     fetchData();
-  }, [selectedDate, type]);
+  }, [authLoading, userId, selectedDate, type]);
 
   const { totalAmount, prevAmount, categoryData, categoryTotalsByKey } =
     useMemo(() => {

--- a/fe/src/hooks/useBudgetData.ts
+++ b/fe/src/hooks/useBudgetData.ts
@@ -12,8 +12,10 @@ import { fetchFixedRulesByMonth } from '@/services/fixed-costs/fixed-costs';
 import { getFixedRuleDates } from '@/services/fixed-costs/getRuleDates';
 import { toast } from 'sonner';
 import { useMemo } from 'react';
+import { useAuth } from '@/providers/AuthProvider';
 
 const useBudgetData = (selectedDate: Date) => {
+  const { userId, isLoading: authLoading } = useAuth();
   const queryClient = useQueryClient();
   const monthKey = formatMonth(selectedDate); // 로컬 시간대 기준 'YYYY-MM' 문자열 생성
 
@@ -21,7 +23,8 @@ const useBudgetData = (selectedDate: Date) => {
   const { data, isLoading: isBudgetLoading } = useQuery({
     // 연-월이 바뀔 때마다 자동으로 새로운 데이터 fetch
     queryKey: ['budgets', monthKey],
-    queryFn: () => fetchBudgets(selectedDate),
+    enabled: !authLoading && !!userId,
+    queryFn: () => fetchBudgets(userId!, selectedDate),
     select: (data: BudgetWithCategory[]) => {
       const totalBudget =
         data?.find((item) => item.category_id === null) || null;
@@ -35,7 +38,8 @@ const useBudgetData = (selectedDate: Date) => {
   // 고정비 규칙 조회
   const { data: fixedRules = [], isLoading: isFixedLoading } = useQuery({
     queryKey: ['fixedRules', monthKey],
-    queryFn: () => fetchFixedRulesByMonth(selectedDate),
+    enabled: !authLoading && !!userId,
+    queryFn: () => fetchFixedRulesByMonth(userId!, selectedDate),
   });
 
   const futureFixedAmount = useMemo(() => {
@@ -62,7 +66,7 @@ const useBudgetData = (selectedDate: Date) => {
     }: {
       amount: number;
       categoryId: string | null;
-    }) => upsertBudget(selectedDate, amount, categoryId),
+    }) => upsertBudget(userId!, selectedDate, amount, categoryId),
     onSuccess: () => {
       // 저장 성공 시 해당 달의 예산 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: ['budgets', monthKey] });
@@ -77,7 +81,7 @@ const useBudgetData = (selectedDate: Date) => {
   const { mutate: saveCategoryBudgets, isPending: isSavingCategories } =
     useMutation({
       mutationFn: (categoryData: { categoryId: string; amount: number }[]) =>
-        upsertCategoryBudgets(selectedDate, categoryData),
+        upsertCategoryBudgets(userId!, selectedDate, categoryData),
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['budgets', monthKey] });
         toast.success('카테고리별 예산이 모두 저장되었습니다.');
@@ -90,7 +94,7 @@ const useBudgetData = (selectedDate: Date) => {
   // 삭제
   const { mutate: removeBudget, isPending: isDeleting } = useMutation({
     mutationFn: (categoryId: string | string[] | null) =>
-      deleteBudgets(selectedDate, categoryId),
+      deleteBudgets(userId!, selectedDate, categoryId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['budgets', monthKey] });
       toast.success('예산이 초기화 되었습니다.');

--- a/fe/src/hooks/useBudgetGuideData.ts
+++ b/fe/src/hooks/useBudgetGuideData.ts
@@ -8,17 +8,17 @@ import { formatLocalDate, formatMonth } from '@/utils/date';
 
 import { EXPENSE_CATEGORY_GROUP_MAP } from '@/constants/analysis';
 import { fetchTransactionByRange } from '@/services/analysis/analysisService';
-import { getCurrentUser } from '@/services/analysis/budgetService';
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/providers/AuthProvider';
 
 const useBudgetGuideData = (selectedDate: Date, targetSaving: number = 0) => {
+  const { userId, isLoading: authLoading } = useAuth();
+
   const { data: rawTransactionData, isLoading } = useQuery({
     queryKey: ['budget-guide', formatMonth(selectedDate)],
+    enabled: !authLoading && !!userId,
     queryFn: async () => {
-      // 현재 유저 정보 가져오기
-      const user = await getCurrentUser();
-
       // 전월 날짜 계산
       const prevMonthStart = new Date(
         selectedDate.getFullYear(),
@@ -41,13 +41,13 @@ const useBudgetGuideData = (selectedDate: Date, targetSaving: number = 0) => {
       // 서비스 함수 호출 (수입 - 지난 달, 지출 - 최근 3개월)
       const [incomeData, expenseData] = await Promise.all([
         fetchTransactionByRange(
-          user.id,
+          userId!,
           'income',
           formatLocalDate(prevMonthStart),
           formatLocalDate(prevMonthEnd)
         ),
         fetchTransactionByRange(
-          user.id,
+          userId!,
           'expense',
           formatLocalDate(threeMonthsStart),
           formatLocalDate(prevMonthEnd)

--- a/fe/src/providers/AuthProvider.tsx
+++ b/fe/src/providers/AuthProvider.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { User } from '@supabase/supabase-js';
 import { supabase } from '@/utils/supabase/client';
 import { Profile } from '@/schemas/profile';
@@ -29,7 +36,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const inFlightRef = useRef(false);
+  const hasInitRef = useRef(false);
+
   const init = async () => {
+    if (hasInitRef.current) return;
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+
     try {
       setIsLoading(true);
       setError(null);
@@ -47,6 +61,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const p = await fetchProfile();
       setProfile(p);
+      hasInitRef.current = true;
     } catch (e) {
       if (e instanceof Error) {
         setError(e.message);
@@ -67,6 +82,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // 로그인/로그아웃 등 인증 상태 변화 구독
     const { data: sub } = supabase.auth.onAuthStateChange(() => {
+      hasInitRef.current = false;
       init();
     });
 

--- a/fe/src/providers/AuthProvider.tsx
+++ b/fe/src/providers/AuthProvider.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '@/utils/supabase/client';
+import { Profile } from '@/schemas/profile';
+
+type AuthState = {
+  user: User | null;
+  userId: string | null;
+  profile: Profile | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthState | null>(null);
+
+async function fetchProfile() {
+  const res = await fetch('/api/profile', { credentials: 'include' });
+  if (!res.ok) throw new Error('프로필 조회 실패');
+  return res.json();
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const init = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const { data, error: userErr } = await supabase.auth.getUser();
+      if (userErr) throw userErr;
+
+      const nextUser = data.user ?? null;
+      setUser(nextUser);
+
+      if (!nextUser) {
+        setProfile(null);
+        return;
+      }
+
+      const p = await fetchProfile();
+      setProfile(p);
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('인증 초기화 실패');
+      }
+
+      setUser(null);
+      setProfile(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    // 최초 1회 초기화
+    init();
+
+    // 로그인/로그아웃 등 인증 상태 변화 구독
+    const { data: sub } = supabase.auth.onAuthStateChange(() => {
+      init();
+    });
+
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      userId: user?.id ?? null,
+      profile,
+      isLoading,
+      error,
+      refresh: init,
+    }),
+    [user, profile, isLoading, error]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx)
+    throw new Error('useAuth는 AuthProvider 내부에서만 사용할 수 있습니다.');
+  return ctx;
+}

--- a/fe/src/providers/AuthProvider.tsx
+++ b/fe/src/providers/AuthProvider.tsx
@@ -12,6 +12,7 @@ type AuthState = {
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+  setProfile: (profile: Profile | null) => void;
 };
 
 const AuthContext = createContext<AuthState | null>(null);
@@ -82,6 +83,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isLoading,
       error,
       refresh: init,
+      setProfile,
     }),
     [user, profile, isLoading, error]
   );

--- a/fe/src/providers/AuthProvider.tsx
+++ b/fe/src/providers/AuthProvider.tsx
@@ -24,8 +24,9 @@ type AuthState = {
 
 const AuthContext = createContext<AuthState | null>(null);
 
-async function fetchProfile() {
+async function fetchProfile(): Promise<Profile | null> {
   const res = await fetch('/api/profile', { credentials: 'include' });
+  if (res.status === 404) return null;
   if (!res.ok) throw new Error('프로필 조회 실패');
   return res.json();
 }
@@ -72,6 +73,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUser(null);
       setProfile(null);
     } finally {
+      inFlightRef.current = false;
       setIsLoading(false);
     }
   };

--- a/fe/src/services/analysis/budgetService.ts
+++ b/fe/src/services/analysis/budgetService.ts
@@ -2,20 +2,8 @@ import { BudgetWithCategory } from '@/types/analysis';
 import { getMonthRange } from '@/utils/date';
 import { supabase } from '@/utils/supabase/client';
 
-// 현재 로그인한 유저 정보 가져오기
-export const getCurrentUser = async () => {
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
-  if (!user || error) throw new Error('로그인이 필요합니다');
-  return user;
-};
-
 // 특정 월의 예산 데이터 가져오기 (Read)
-export const fetchBudgets = async (date: Date) => {
-  const user = await getCurrentUser();
-
+export const fetchBudgets = async (userId: string, date: Date) => {
   // 해당 월의 1일
   const { startDate } = getMonthRange(date);
 
@@ -31,7 +19,7 @@ export const fetchBudgets = async (date: Date) => {
         category_key
       )`
     )
-    .eq('user_id', user.id)
+    .eq('user_id', userId)
     .eq('budget_month', startDate);
 
   if (error) throw error;
@@ -49,17 +37,17 @@ export const fetchBudgets = async (date: Date) => {
 
 // 예산 데이터 저장 및 수정 (Upsert)
 export const upsertBudget = async (
+  userId: string,
   date: Date,
   amount: number,
   categoryId: string | null = null
 ) => {
-  const user = await getCurrentUser();
   const { startDate } = getMonthRange(date);
 
   const { data, error } = await supabase.from('budgets').upsert(
     [
       {
-        user_id: user.id,
+        user_id: userId,
         budget_month: startDate,
         category_id: categoryId,
         amount: amount,
@@ -76,14 +64,14 @@ export const upsertBudget = async (
 
 // 카테고리 예산 일괄 저장 (배열)
 export const upsertCategoryBudgets = async (
+  userId: string,
   date: Date,
   categoryData: { categoryId: string; amount: number }[]
 ) => {
-  const user = await getCurrentUser();
   const { startDate } = getMonthRange(date);
 
   const upsertRows = categoryData.map((item) => ({
-    user_id: user.id,
+    user_id: userId,
     budget_month: startDate,
     category_id: item.categoryId,
     amount: item.amount,
@@ -99,16 +87,16 @@ export const upsertCategoryBudgets = async (
 
 // 예산 삭제 (Delete)
 export const deleteBudgets = async (
+  userId: string,
   date: Date,
   categoryId: string | string[] | null = null
 ) => {
-  const user = await getCurrentUser();
   const { startDate } = getMonthRange(date);
 
   let query = supabase
     .from('budgets')
     .delete()
-    .eq('user_id', user.id)
+    .eq('user_id', userId)
     .eq('budget_month', startDate);
 
   if (categoryId === 'ALL_CATEGORIES') {

--- a/fe/src/services/budgets/budget.ts
+++ b/fe/src/services/budgets/budget.ts
@@ -1,11 +1,9 @@
 import { getMonthRange } from '@/utils/date';
-import { createClient } from '@/utils/supabase/server';
 import type { Budget } from '@/types/analysis';
+import { requireUserServer } from '@/utils/supabase/requireUserServer';
 
 export const fetchBudgetsServer = async (date: Date): Promise<Budget[]> => {
-  const supabase = await createClient();
-  const { data: auth, error: authError } = await supabase.auth.getUser();
-  if (authError || !auth.user) throw new Error('로그인이 필요합니다');
+  const { supabase, user } = await requireUserServer();
 
   const { startDate } = getMonthRange(date);
 
@@ -18,7 +16,7 @@ export const fetchBudgetsServer = async (date: Date): Promise<Budget[]> => {
          category_key
        )`
     )
-    .eq('user_id', auth.user.id)
+    .eq('user_id', user.id)
     .eq('budget_month', startDate);
 
   if (error) throw error;

--- a/fe/src/services/fixed-costs/fixed-costs.ts
+++ b/fe/src/services/fixed-costs/fixed-costs.ts
@@ -6,20 +6,8 @@ import type {
 } from '@/types/fixed-costs';
 import { getMonthRange, getWeekRange } from '@/utils/date';
 
-export const requireUserId = async () => {
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
-
-  if (!user || error) throw new Error('로그인이 필요합니다');
-  return user.id;
-};
-
 // 고정비 규칙 목록 조회
-export const fetchFixedRules = async () => {
-  const userId = await requireUserId();
-
+export const fetchFixedRules = async (userId: string) => {
   const { data, error } = await supabase
     .from('fixed_rules')
     .select('*')
@@ -31,9 +19,10 @@ export const fetchFixedRules = async () => {
 };
 
 // 고정비 규칙 생성
-export const createFixedRule = async (input: CreateFixedRuleInput) => {
-  const userId = await requireUserId();
-
+export const createFixedRule = async (
+  userId: string,
+  input: CreateFixedRuleInput
+) => {
   const payload = {
     user_id: userId,
     ...input,
@@ -51,11 +40,10 @@ export const createFixedRule = async (input: CreateFixedRuleInput) => {
 
 // 고정비 규칙 수정
 export const updateFixedRule = async (
+  userId: string,
   id: string,
   input: CreateFixedRuleInput
 ) => {
-  const userId = await requireUserId();
-
   const { data, error } = await supabase
     .from('fixed_rules')
     .update(input)
@@ -82,11 +70,13 @@ function getCurrentPeriod(cycle: IFixedRule['cycle']) {
 
 // '포함' 옵션일 때, 이번달/이번주에 생성된 고정비 거래를 새 규칙 값으로 동기화
 export const updateFixedRuleInPeriod = async ({
+  userId,
   fixedRuleId,
   cycle,
   input,
   scope,
 }: {
+  userId: string;
   fixedRuleId: string;
   cycle: IFixedRule['cycle'];
   input: UpdateFixedRuleInPeriod;
@@ -94,7 +84,6 @@ export const updateFixedRuleInPeriod = async ({
 }) => {
   if (scope === 'EXCLUDE_CURRENT') return [];
 
-  const userId = await requireUserId();
   const { startDate, endDate } = getCurrentPeriod(cycle);
 
   const { data, error } = await supabase
@@ -117,19 +106,22 @@ export const updateFixedRuleInPeriod = async ({
 
 // 고정비 규칙 수정 + 적용 범위에 따른 거래 동기화 처리
 export const updateFixedRuleWithScope = async ({
+  userId,
   id,
   ruleInput,
   scope,
 }: {
+  userId: string;
   id: string;
   ruleInput: CreateFixedRuleInput;
   scope: ApplyScope;
 }) => {
   // 규칙 row 업데이트
-  const updatedRule = await updateFixedRule(id, ruleInput);
+  const updatedRule = await updateFixedRule(userId, id, ruleInput);
 
   // 포함이면 이번 기간 거래 업데이트
   await updateFixedRuleInPeriod({
+    userId,
     fixedRuleId: id,
     cycle: updatedRule.cycle,
     input: {
@@ -145,8 +137,10 @@ export const updateFixedRuleWithScope = async ({
 };
 
 // 해당 월에 적용되는 고정비 규칙 조회
-export const fetchFixedRulesByMonth = async (monthDate: Date) => {
-  const userId = await requireUserId();
+export const fetchFixedRulesByMonth = async (
+  userId: string,
+  monthDate: Date
+) => {
   const { startDate, endDate } = getMonthRange(monthDate);
 
   const { data, error } = await supabase
@@ -161,9 +155,7 @@ export const fetchFixedRulesByMonth = async (monthDate: Date) => {
 };
 
 // 고정비 항목 삭제
-export const deleteFixedRule = async (ruleId: string) => {
-  const userId = await requireUserId();
-
+export const deleteFixedRule = async (userId: string, ruleId: string) => {
   const { error } = await supabase
     .from('fixed_rules')
     .delete()

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -1,17 +1,10 @@
 import { getMonthRange } from '@/utils/date';
 import type { IFixedRule } from '@/types/fixed-costs';
-import { createClient } from '@/utils/supabase/server';
+import { requireUserServer } from '@/utils/supabase/requireUserServer';
 
 // 해당 월에 적용되는 고정비 규칙 조회 (서버용)
 export const fetchFixedRulesByMonthServer = async (monthDate: Date) => {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (!user || userError) throw new Error('로그인이 필요합니다');
+  const { supabase, user } = await requireUserServer();
 
   const { startDate, endDate } = getMonthRange(monthDate);
 

--- a/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.client.ts
@@ -1,16 +1,15 @@
 import { supabase } from '@/utils/supabase/client';
 import { getMonthRange } from '@/utils/date';
-import { requireUserId } from './fixed-costs';
 import { syncByMonthShared } from './syncFixedTransactions.shared';
 import { PG_ERROR } from '@/constants/postgres';
 
 // 클라이언트 환경에서 고정비 규칙 기반 월별 거래 동기화
 export const syncByMonthClient = async (
+  userId: string,
   monthDate: Date,
   generateThroughDate?: string,
   options?: { isGuest?: boolean }
 ) => {
-  const userId = await requireUserId();
   const { startDate, endDate } = getMonthRange(monthDate);
 
   return syncByMonthShared(

--- a/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
+++ b/fe/src/services/fixed-costs/syncFixedTransactions.server.ts
@@ -1,6 +1,6 @@
-import { createClient } from '@/utils/supabase/server';
 import { syncByMonthShared } from './syncFixedTransactions.shared';
 import { PG_ERROR } from '@/constants/postgres';
+import { requireUserServer } from '@/utils/supabase/requireUserServer';
 
 // 서버 환경에서 고정비 규칙 기반 월별 거래 동기화
 export const syncByMonthServer = async ({
@@ -14,13 +14,7 @@ export const syncByMonthServer = async ({
   endDate: string;
   generateThroughDate?: string;
 }) => {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) throw new Error('User not authenticated');
+  const { supabase, user } = await requireUserServer();
 
   const { data: profile } = await supabase
     .from('profiles')

--- a/fe/src/utils/supabase/requireUserServer.ts
+++ b/fe/src/utils/supabase/requireUserServer.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@/utils/supabase/server';
+
+export async function requireUserServer() {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+
+  if (error || !data.user) {
+    throw new Error('로그인이 필요합니다');
+  }
+
+  return { supabase, user: data.user };
+}


### PR DESCRIPTION
## PR 개요
- 인증 및 사용자 상태 로직을 UI 컴포넌트 단위에서 분리하고, 전역 AuthProvider를 기준점으로 통합하였습니다.

## 변경 사항
### 1. 전역 AuthProvider 도입 및 인증 초기화 흐름 통합
- 앱 진입 시 AuthProvider에서 사용자(`userId`) 및 프로필을 단일 진입점에서 초기화
- `/api/profile` 호출을 AuthProvider에서 1회만 수행하도록 구조 개선
- 인증 초기화 중복 실행 방지를 위한 in-flight / 초기화 제어 로직 보완

### 2. 클라이언트 측 중복 getUser 호출 제거
- Header / ProfilePanelTrigger / MyInfo 등 UI 컴포넌트에서 `useQuery(['profile'])` 제거
- `supabase.auth.getUser()` 직접 호출을 제거하고 `useAuth().userId` 사용
  - 가계부 등록/수정, OCR 업로드 submit 로직의 `getUser()` 호출 제거
  - 고정비 목록 조회/생성/수정/동기화 로직의 `getUser()` 호출 제거
  - 분석 페이지 클라이언트 로직에서 `getCurrentUser()` 제거
- 클라이언트 인증 가드 로직을 AuthProvider 기준(`authLoading / userId`)으로 통일

### 3. 서버 인증 로직 패턴 통일
- 서버 코드에서 반복되던 `createClient() + getUser()` 패턴을 `requireUserServer()` 유틸로 통일
- 고정비, 거래 조회, 분석 등 서버 서비스 로직의 인증 처리 가독성 개선

## 리뷰 요청 사항
- AuthProvider의 인증 초기화 흐름 및 중복 방지 로직이 적절한지 확인 부탁드립니다.

## 추후 할 일
- [x] 온보딩 새로고침 시 프로필 없음 에러 처리 #102 