### PR TITLE
[fix] 온보딩 중 프로필 미존재 상태를 정상 플로우로 처리

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/fe/src/app/(app)/onboarding/page.tsx
+++ b/fe/src/app/(app)/onboarding/page.tsx
@@ -15,8 +15,10 @@ import { OnboardingProfileValues } from '@/schemas/profile';
 
 import IntroPanel from '@/components/onboarding/IntroPanel';
 import { INTRO_STEPS } from '@/constants/onboarding';
+import { useAuth } from '@/providers/AuthProvider';
 
 export default function OnboardingPage() {
+  const { refresh } = useAuth();
   const [phase, setPhase] = useState<'form' | 'intro'>('form');
   const [introStep, setIntroStep] = useState(0);
   const [isExiting, setIsExiting] = useState(false);
@@ -46,6 +48,9 @@ export default function OnboardingPage() {
     }
 
     toast.success('기본 정보가 저장되었어요');
+
+    // 전역 Auth 상태(profile) 동기화
+    await refresh();
 
     // 온보딩 소개 단계로 전환
     setIntroStep(0);

--- a/fe/src/app/api/profile/route.ts
+++ b/fe/src/app/api/profile/route.ts
@@ -46,13 +46,30 @@ export async function GET() {
     .from('profiles')
     .select('nickname, birth_date, gender, profile_image_url, is_guest')
     .eq('id', user.id)
-    .single();
+    .maybeSingle();
 
-  if (selectError || !data) {
-    return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
+  if (selectError) {
+    return NextResponse.json(
+      { ok: false, message: 'Failed to fetch profile' },
+      { status: 500 }
+    );
   }
 
-  return NextResponse.json(data);
+  // 온보딩 진행 중
+  if (!data) {
+    return NextResponse.json({
+      ok: true,
+      state: 'ONBOARDING',
+      profile: null,
+    });
+  }
+
+  // 온보딩 완료
+  return NextResponse.json({
+    ok: true,
+    state: 'ONBOARDED',
+    profile: data,
+  });
 }
 
 // onboarding - 프로필 수정

--- a/fe/src/components/my-info/LogoutButton.tsx
+++ b/fe/src/components/my-info/LogoutButton.tsx
@@ -3,6 +3,17 @@
 import { supabase } from '@/utils/supabase/client';
 import { useRouter } from 'next/navigation';
 import { Button } from '../ui/button';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 
 export default function LogoutButton() {
   const router = useRouter();
@@ -15,8 +26,26 @@ export default function LogoutButton() {
   };
 
   return (
-    <Button type="button" onClick={handleLogout} variant="destructive">
-      로그아웃
-    </Button>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="destructive">
+          로그아웃
+        </Button>
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>로그아웃하시겠어요?</AlertDialogTitle>
+          <AlertDialogDescription>
+            로그아웃하면 로그인 페이지로 이동합니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction onClick={handleLogout}>로그아웃</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/fe/src/components/my-info/MyInfo.tsx
+++ b/fe/src/components/my-info/MyInfo.tsx
@@ -27,7 +27,7 @@ async function updateProfile(values: ProfilePatchValues): Promise<Profile> {
 
 export default function MyInfo() {
   const [isEditing, setIsEditing] = useState(false);
-  const { profile, isLoading, error, setProfile } = useAuth();
+  const { userId, profile, isLoading, error, setProfile } = useAuth();
 
   // 프로필 수정 뮤테이션
   const { mutateAsync } = useMutation({
@@ -47,11 +47,14 @@ export default function MyInfo() {
     setIsEditing(false);
   };
 
+  if (!userId) return null;
+  if (!profile) return null;
+
   if (isLoading) {
     return <MyInfoSkeleton />;
   }
 
-  if (error || !profile) {
+  if (error) {
     return (
       <div className="p-4 text-sm text-red-500">
         프로필을 불러오지 못했습니다.

--- a/fe/src/components/ui/alert-dialog.tsx
+++ b/fe/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/fe/src/providers/AuthProvider.tsx
+++ b/fe/src/providers/AuthProvider.tsx
@@ -24,11 +24,22 @@ type AuthState = {
 
 const AuthContext = createContext<AuthState | null>(null);
 
+type ProfileApiResponse =
+  | { ok: true; state: 'ONBOARDING'; profile: null }
+  | { ok: true; state: 'ONBOARDED'; profile: Profile }
+  | { ok: false; message: string };
+
 async function fetchProfile(): Promise<Profile | null> {
   const res = await fetch('/api/profile', { credentials: 'include' });
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error('프로필 조회 실패');
-  return res.json();
+  const json = (await res
+    .json()
+    .catch(() => null)) as ProfileApiResponse | null;
+  if (!json) throw new Error('프로필 응답 처리 실패');
+
+  if (!res.ok || json.ok === false) {
+    throw new Error(json.ok === false ? json.message : '프로필 조회 실패');
+  }
+  return json.state === 'ONBOARDED' ? json.profile : null;
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -57,6 +68,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (!nextUser) {
         setProfile(null);
+        hasInitRef.current = true;
         return;
       }
 

--- a/fe/yarn.lock
+++ b/fe/yarn.lock
@@ -597,6 +597,18 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
   integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
 
+"@radix-ui/react-alert-dialog@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz#fa751d0fdd9aa2a90961c9901dba18e638dd4b41"
+  integrity sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dialog" "1.1.15"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+
 "@radix-ui/react-arrow@1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz#e14a2657c81d961598c5e72b73dd6098acc04f09"
@@ -654,7 +666,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
   integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
 
-"@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.15":
+"@radix-ui/react-dialog@1.1.15", "@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.15":
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
   integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==


### PR DESCRIPTION
## PR 개요
- 온보딩 진행 중 `profiles` row가 아직 없는 정상 사용자 상태를 에러로 처리하던 문제를 개선했습니다.
- 프로필 미존재를 온보딩 진행 중인 정상 상태로 재정의하여, 온보딩 페이지 새로고침 시에도 에러 없이 동일한 흐름이 유지되도록 수정했습니다.

## 변경 사항
### 1. 프로필 미존재 상태를 온보딩 진행 중 정상 상태로 처리
- `/api/profile` GET에서 `profiles` row가 없는 경우 `ONBOARDING` 상태로 정상 응답하도록 수정
- `.single()`을 `.maybeSingle()`로 변경하여 row 미존재 케이스를 명확히 분리
### 2. AuthProvider에서 온보딩 상태 프로필 응답 정상 처리
- `/api/profile` 응답을 상태 기반(`ONBOARDING` / `ONBOARDED`)으로 파싱하도록 수정
- 온보딩 진행 중에는 프로필 조회 실패로 간주하지 않고 `profile: null`로 처리
### 3. 온보딩 저장 후 전역 인증 상태 동기화
- 온보딩 기본 정보 저장(PUT) 성공 후 `AuthProvider.refresh()`를 호출
- 전역 프로필 상태를 즉시 갱신하도록 개선

## 스크린샷
before | after
-- | --
<img width="953" height="660" alt="스크린샷 2026-01-19 17 44 31" src="https://github.com/user-attachments/assets/28bf4bde-1de8-4d31-b68c-107e17692fb2" /> | <img width="957" height="670" alt="스크린샷 2026-01-19 23 16 59" src="https://github.com/user-attachments/assets/b28d1284-8e7a-4af8-ad8a-eb9d6a524a57" />

## 리뷰 요청 사항
- 온보딩 페이지 기본 정보 입력 시 기존 프로필 미존재 에러가 발생하지 않는지 확인 부탁드립니다.
  - 정보 입력 중 새로고침 시에도 동일하게 에러가 발생하지 않는지

## 추후 할 일
- [x] 온보딩 스탭 상태 저장 #104 