### PR TITLE
[feat] 온보딩 소개 단계 스텝 유지 및 라우트 구조 개선

### DIFF
--- a/fe/src/app/(app)/onboarding/intro/page.tsx
+++ b/fe/src/app/(app)/onboarding/intro/page.tsx
@@ -11,28 +11,32 @@ import {
 import { Button } from '@/components/ui/button';
 import IntroPanel from '@/components/onboarding/IntroPanel';
 import { INTRO_STEPS } from '@/constants/onboarding';
+import { IntroPanelSkeleton } from '@/components/onboarding/IntroPanelSkeleton';
 
 const INTRO_STEP_KEY = 'spenny:introStep';
 
 export default function OnboardingIntroPage() {
   const [introStep, setIntroStep] = useState(0);
   const [isExiting, setIsExiting] = useState(false);
+  const [isRestored, setIsRestored] = useState(false);
 
   useEffect(() => {
     const raw = localStorage.getItem(INTRO_STEP_KEY);
-    if (!raw) return;
+    if (raw) {
+      const saved = Number(raw);
+      if (!Number.isNaN(saved)) {
+        const safeStep = Math.min(Math.max(0, saved), INTRO_STEPS.length - 1);
+        setIntroStep(safeStep);
+      }
+    }
 
-    const saved = Number(raw);
-    if (Number.isNaN(saved)) return;
-
-    const safeStep = Math.min(Math.max(0, saved), INTRO_STEPS.length - 1);
-
-    setIntroStep(safeStep);
+    setIsRestored(true);
   }, []);
 
   useEffect(() => {
+    if (!isRestored) return;
     localStorage.setItem(INTRO_STEP_KEY, String(introStep));
-  }, [introStep]);
+  }, [isRestored, introStep]);
 
   const clearStep = () => {
     localStorage.removeItem(INTRO_STEP_KEY);
@@ -51,6 +55,10 @@ export default function OnboardingIntroPage() {
     setIntroStep((s) => Math.min(INTRO_STEPS.length - 1, s + 1));
 
   const isLastIntro = introStep === INTRO_STEPS.length - 1;
+
+  if (!isRestored) {
+    return <IntroPanelSkeleton stepsCount={INTRO_STEPS.length} />;
+  }
 
   return (
     <div className="fixed inset-0 z-50">

--- a/fe/src/app/(app)/onboarding/intro/page.tsx
+++ b/fe/src/app/(app)/onboarding/intro/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Card,
   CardContent,
@@ -12,13 +12,36 @@ import { Button } from '@/components/ui/button';
 import IntroPanel from '@/components/onboarding/IntroPanel';
 import { INTRO_STEPS } from '@/constants/onboarding';
 
+const INTRO_STEP_KEY = 'spenny:introStep';
+
 export default function OnboardingIntroPage() {
   const [introStep, setIntroStep] = useState(0);
   const [isExiting, setIsExiting] = useState(false);
 
+  useEffect(() => {
+    const raw = localStorage.getItem(INTRO_STEP_KEY);
+    if (!raw) return;
+
+    const saved = Number(raw);
+    if (Number.isNaN(saved)) return;
+
+    const safeStep = Math.min(Math.max(0, saved), INTRO_STEPS.length - 1);
+
+    setIntroStep(safeStep);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(INTRO_STEP_KEY, String(introStep));
+  }, [introStep]);
+
+  const clearStep = () => {
+    localStorage.removeItem(INTRO_STEP_KEY);
+  };
+
   const exit = () => {
     if (isExiting) return;
     setIsExiting(true);
+    clearStep();
     window.location.replace('/');
   };
 

--- a/fe/src/app/(app)/onboarding/intro/page.tsx
+++ b/fe/src/app/(app)/onboarding/intro/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import IntroPanel from '@/components/onboarding/IntroPanel';
+import { INTRO_STEPS } from '@/constants/onboarding';
+
+export default function OnboardingIntroPage() {
+  const [introStep, setIntroStep] = useState(0);
+  const [isExiting, setIsExiting] = useState(false);
+
+  const exit = () => {
+    if (isExiting) return;
+    setIsExiting(true);
+    window.location.replace('/');
+  };
+
+  // 온보딩 단계 이동 함수
+  const goPrev = () => setIntroStep((s) => Math.max(0, s - 1));
+  const goNext = () =>
+    setIntroStep((s) => Math.min(INTRO_STEPS.length - 1, s + 1));
+
+  const isLastIntro = introStep === INTRO_STEPS.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+      <div className="relative flex min-h-dvh items-center justify-center p-4">
+        <div className="w-full max-w-lg md:max-w-3xl">
+          <Card className="max-h-[90dvh] overflow-hidden">
+            <CardHeader className="relative space-y-2">
+              {!isLastIntro && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={isExiting}
+                  className="absolute -top-3 right-2"
+                  onClick={exit}
+                >
+                  건너뛰기
+                </Button>
+              )}
+              <CardTitle className="text-xl">
+                {INTRO_STEPS[introStep].title}
+              </CardTitle>
+              <CardDescription>
+                {INTRO_STEPS[introStep].description}
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="max-h-[70dvh] overflow-y-auto">
+              <IntroPanel
+                steps={INTRO_STEPS}
+                introStep={introStep}
+                isLastIntro={isLastIntro}
+                isExiting={isExiting}
+                onPrev={goPrev}
+                onNext={goNext}
+                onExit={exit}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/app/(app)/onboarding/page.tsx
+++ b/fe/src/app/(app)/onboarding/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   Card,
   CardContent,
@@ -7,30 +8,15 @@ import {
   CardTitle,
   CardDescription,
 } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
-
 import ProfileForm from '@/components/onboarding/ProfileForm';
 import { OnboardingProfileValues } from '@/schemas/profile';
-
-import IntroPanel from '@/components/onboarding/IntroPanel';
-import { INTRO_STEPS } from '@/constants/onboarding';
 import { useAuth } from '@/providers/AuthProvider';
 
 export default function OnboardingPage() {
+  const router = useRouter();
   const { refresh } = useAuth();
-  const [phase, setPhase] = useState<'form' | 'intro'>('form');
-  const [introStep, setIntroStep] = useState(0);
-  const [isExiting, setIsExiting] = useState(false);
-
   const [serverError, setServerError] = useState<string | null>(null);
-
-  const exitOnboarding = () => {
-    if (isExiting) return;
-    setIsExiting(true);
-
-    window.location.replace('/');
-  };
 
   const handleProfileSubmit = async (values: OnboardingProfileValues) => {
     setServerError(null); // 서버 에러 상태 초기화
@@ -53,16 +39,8 @@ export default function OnboardingPage() {
     await refresh();
 
     // 온보딩 소개 단계로 전환
-    setIntroStep(0);
-    setPhase('intro');
+    router.replace('/onboarding/intro');
   };
-
-  // 온보딩 단계 이동 함수
-  const goPrev = () => setIntroStep((s) => Math.max(0, s - 1));
-  const goNext = () =>
-    setIntroStep((s) => Math.min(INTRO_STEPS.length - 1, s + 1));
-
-  const isLastIntro = introStep === INTRO_STEPS.length - 1;
 
   return (
     <div className="fixed inset-0 z-50">
@@ -73,60 +51,23 @@ export default function OnboardingPage() {
         <div className="w-full max-w-lg md:max-w-3xl">
           <Card className="max-h-[90dvh] overflow-hidden">
             <CardHeader className="relative space-y-2">
-              {phase === 'form' ? (
-                <>
-                  <CardTitle className="text-xl">기본 정보 설정</CardTitle>
-                  <CardDescription>
-                    서비스를 시작하기 위해 필수 정보만 먼저 입력해주세요.
-                  </CardDescription>
-                </>
-              ) : (
-                <>
-                  {!isLastIntro && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isExiting}
-                      className="absolute -top-3 right-2"
-                      onClick={exitOnboarding}
-                    >
-                      건너뛰기
-                    </Button>
-                  )}
-                  <CardTitle className="text-xl">
-                    {INTRO_STEPS[introStep].title}
-                  </CardTitle>
-                  <CardDescription>
-                    {INTRO_STEPS[introStep].description}
-                  </CardDescription>
-                </>
-              )}
+              <CardTitle className="text-xl">기본 정보 설정</CardTitle>
+              <CardDescription>
+                서비스를 시작하기 위해 필수 정보만 먼저 입력해주세요.
+              </CardDescription>
             </CardHeader>
             <CardContent className="max-h-[70dvh] overflow-y-auto">
-              {phase === 'form' && serverError && (
+              {serverError && (
                 <p className="mb-4 text-sm text-red-500">{serverError}</p>
               )}
-
-              {phase === 'form' ? (
-                <ProfileForm
-                  defaultValues={{
-                    nickname: '',
-                    birth_date: '',
-                    gender: 'male',
-                  }}
-                  onSubmit={handleProfileSubmit}
-                />
-              ) : (
-                <IntroPanel
-                  steps={INTRO_STEPS}
-                  introStep={introStep}
-                  isLastIntro={isLastIntro}
-                  isExiting={isExiting}
-                  onPrev={goPrev}
-                  onNext={goNext}
-                  onExit={exitOnboarding}
-                />
-              )}
+              <ProfileForm
+                defaultValues={{
+                  nickname: '',
+                  birth_date: '',
+                  gender: 'male',
+                }}
+                onSubmit={handleProfileSubmit}
+              />
             </CardContent>
           </Card>
         </div>

--- a/fe/src/components/onboarding/IntroPanelSkeleton.tsx
+++ b/fe/src/components/onboarding/IntroPanelSkeleton.tsx
@@ -1,0 +1,59 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function IntroPanelSkeleton({ stepsCount }: { stepsCount: number }) {
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+      <div className="relative flex min-h-dvh items-center justify-center p-4">
+        <div className="w-full max-w-lg md:max-w-3xl">
+          <Card className="max-h-[90dvh] overflow-hidden">
+            <CardHeader className="relative space-y-2">
+              {/* 건너뛰기 버튼 */}
+              <div className="absolute -top-3 right-2">
+                <Skeleton className="h-9 w-20" />
+              </div>
+
+              {/* title/desc */}
+              <Skeleton className="h-6 w-2/3" />
+              <Skeleton className="h-4 w-full" />
+            </CardHeader>
+
+            <CardContent className="max-h-[70dvh] overflow-y-auto">
+              <div className="space-y-6">
+                {/* media */}
+                <div className="flex gap-3 overflow-hidden">
+                  <div className="relative h-75 w-full md:h-90">
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                </div>
+
+                {/* 하단 컨트롤 */}
+                <div className="grid grid-cols-3 items-center">
+                  {/* 이전 버튼 */}
+                  <div className="justify-self-start">
+                    <Skeleton className="h-10 w-20" />
+                  </div>
+
+                  {/* 중앙 인디케이터 */}
+                  <div className="justify-self-center">
+                    <div className="flex items-center justify-center gap-3">
+                      {Array.from({ length: stepsCount }).map((_, i) => (
+                        <Skeleton key={i} className="h-2 w-2 rounded-full" />
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* 다음 버튼 */}
+                  <div className="justify-self-end">
+                    <Skeleton className="h-10 w-20" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/utils/supabase/middleware.ts
+++ b/fe/src/utils/supabase/middleware.ts
@@ -1,10 +1,29 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
+const isPublicAsset = (pathname: string) => {
+  // Next 내부 정적 자원, 파비콘 등
+  if (
+    pathname.startsWith('/_next') ||
+    pathname === '/favicon.ico' ||
+    pathname === '/robots.txt' ||
+    pathname === '/sitemap.xml'
+  )
+    return true;
+
+  // 이미지 파일
+  return /\.(png|jpg|jpeg|gif|svg|webp|ico)$/.test(pathname);
+};
+
 export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({
-    request,
-  });
+  const pathname = request.nextUrl.pathname;
+
+  // 정적 자원은 인증/세션 로직 제외
+  if (isPublicAsset(pathname)) {
+    return NextResponse.next({ request });
+  }
+
+  let supabaseResponse = NextResponse.next({ request });
 
   // With Fluid compute, don't put this client in a global environment
   // variable. Always create a new one on each request.
@@ -20,9 +39,7 @@ export async function updateSession(request: NextRequest) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value)
           );
-          supabaseResponse = NextResponse.next({
-            request,
-          });
+          supabaseResponse = NextResponse.next({ request });
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           );
@@ -40,18 +57,12 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
   const user = data?.claims;
 
-  const pathname = request.nextUrl.pathname;
-
-  // 정적 이미지 파일은 인증 체크 제외
-  if (pathname.match(/\.(png|jpg|jpeg|gif|svg|webp|ico)$/)) {
-    return supabaseResponse;
-  }
-
   const isAuthPath = pathname.startsWith('/auth');
   const isLoginPath = pathname.startsWith('/login');
   const isOnboardingPath = pathname.startsWith('/onboarding');
   const isOnboardingIntroPath = pathname.startsWith('/onboarding/intro');
 
+  // 비로그인 : login/auth만 허용
   if (!user) {
     if (!isLoginPath && !isAuthPath) {
       // no user, potentially respond by redirecting the user to the login page
@@ -64,14 +75,19 @@ export async function updateSession(request: NextRequest) {
 
   const userId = user.sub; // claims의 subject = auth uid(uuid)
 
-  // 유저 프로필 존재 여부 조회
+  // 로그인 : 프로필 존재 여부 조회
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .maybeSingle();
 
-  const hasProfile = !!profile && !profileError;
+  if (profileError) {
+    console.error('[middleware] profile fetch error', profileError);
+    return supabaseResponse;
+  }
+
+  const hasProfile = !!profile;
 
   // 로그인 상태에서 login 페이지 접근 차단
   if (isLoginPath) {
@@ -92,7 +108,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   // 온보딩 완료면 onboarding 접근 차단
-  if (hasProfile && isOnboardingPath && !isOnboardingIntroPath) {
+  if (isOnboardingPath && !isOnboardingIntroPath) {
     const url = request.nextUrl.clone();
     url.pathname = '/';
     return NextResponse.redirect(url);

--- a/fe/src/utils/supabase/middleware.ts
+++ b/fe/src/utils/supabase/middleware.ts
@@ -50,6 +50,7 @@ export async function updateSession(request: NextRequest) {
   const isAuthPath = pathname.startsWith('/auth');
   const isLoginPath = pathname.startsWith('/login');
   const isOnboardingPath = pathname.startsWith('/onboarding');
+  const isOnboardingIntroPath = pathname.startsWith('/onboarding/intro');
 
   if (!user) {
     if (!isLoginPath && !isAuthPath) {
@@ -91,7 +92,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   // 온보딩 완료면 onboarding 접근 차단
-  if (hasProfile && isOnboardingPath) {
+  if (hasProfile && isOnboardingPath && !isOnboardingIntroPath) {
     const url = request.nextUrl.clone();
     url.pathname = '/';
     return NextResponse.redirect(url);


### PR DESCRIPTION
## PR 개요
- 온보딩 소개 단계에서 새로고침 시 진행 중이던 스텝이 유지되지 않고 홈으로 이동되던 UX 문제를 개선했습니다.

## 변경 사항
- 온보딩 소개 단계를 `/onboarding/intro` 라우트로 분리
- 소개 단계 새로고침 시 스텝을 유지하도록 localStorage 기반 상태 복원 추가
- 스텝 복원 전 UI 깜빡임 방지를 위해 소개 모달 전체 스켈레톤 UI 적용
- 온보딩 소개 페이지 접근을 허용하도록 미들웨어 조건 예외 처리

## 스크린샷 (선택)
before | after
-- | --
<img height="600" src="https://github.com/user-attachments/assets/2b3809ba-be92-4261-9c49-bc73a2b8be1d" /> | <img height="600" src="https://github.com/user-attachments/assets/1f3b9cb7-0da2-4811-aae8-1635eb9deaad" />


## 리뷰 요청 사항
- 온보딩 소개 단계에서 스텝 이동 시, 현재 스텝이 localStorage에 정상적으로 저장되는지 확인 부탁드립니다.
- 소개 단계에서 새로고침 시, 저장된 스텝이 정상적으로 복원되어 동일 단계가 노출되는지 확인 부탁드립니다.

## 추후 할 일
- [x] 고정비 페이지 SSR #110 