### PR TITLE
[refactor] 캘린더 데이터 페칭 방식 변경 및 리팩토링

### DIFF
--- a/fe/src/app/(app)/history/actions.ts
+++ b/fe/src/app/(app)/history/actions.ts
@@ -3,6 +3,7 @@ import { syncByMonthServer } from '@/services/fixed-costs/syncFixedTransactions.
 import { formatLocalDate } from '@/utils/date';
 import { requireUserServer } from '@/utils/supabase/requireUserServer';
 import { revalidatePath } from 'next/cache';
+import { getMonthRange } from '@/utils/date';
 
 export interface TransactionFilters {
   type?: 'income' | 'expense';
@@ -78,7 +79,20 @@ export const getTransaction = async (
 
   return data || [];
 };
-
+export const getMonthTransactions= async(month : string)=>{
+  const { supabase, user } = await requireUserServer();
+  const { startDate, endDate} = getMonthRange(new Date(`${month}-1`))
+  
+  const { data, error } = await supabase
+    .from('transactions')
+    .select('*')
+    .eq('user_id', user.id)
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .order('date', { ascending: false });
+    if (error) throw error;
+    return data || [];
+}
 export async function revalidateTransactions() {
   revalidatePath('/history');
   revalidatePath('/');

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -36,7 +36,7 @@ async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
 
   // 당월 데이터 fetch
   const [transactions, budgets, fixedRules] = await Promise.all([
-    getMonthTransactions(`${currentMonth}-01`),
+    getMonthTransactions(currentMonth),
     fetchBudgetsServer(currentMonthDate),
     fetchFixedRulesByMonthServer(currentMonthDate),
   ]);

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -1,11 +1,6 @@
-import { Calendar } from '@/components/calendar/Calendar';
-import { getTransaction } from './history/actions';
-import { TransactionFilters } from './history/actions';
+import { getTransaction,getMonthTransactions } from './history/actions';
 import { Suspense } from 'react';
 import { formatLocalDate, formatMonth } from '@/utils/date';
-import { getMonthRange } from '@/utils/date';
-import { CalendarProvider } from '@/context/CalendarContext';
-import { TransactionProvider } from './history/TransactionContext';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
 import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 import { getTotalBudgetAmount } from '@/utils/budget';
@@ -19,97 +14,41 @@ import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs';
 import { buildDailyRecChartData } from '@/services/daily-recommendation/chart';
 import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
 import { SpendingTransaction } from '@/services/daily-recommendation/spendingPattern';
-import { cache } from 'react';
 
-const getCachedTransaction = cache(
-  async (startDate: string, endDate: string, includeFixed: boolean) => {
-    return await getTransaction({ start_date: startDate, end_date: endDate }, includeFixed);
-  }
-);
-const getCachedBudgets = cache(async (monthDate: Date) => {
-  return await fetchBudgetsServer(monthDate);
-});
-
-const getCachedFixedRules = cache(async (monthDate: Date) => {
-  return await fetchFixedRulesByMonthServer(monthDate);
-});
-interface PageProps {
-  searchParams: Promise<{
-    month?: string;
-    selected_date?: string;
-  }>;
-}
-
-export default async function Home({ searchParams }: PageProps) {
-  const params = await searchParams;
-
-  const currentMonth = params.month || formatMonth(new Date());
-  const monthDate = new Date(`${currentMonth}-01`);
-  const { startDate, endDate } = getMonthRange(monthDate);
+export default async function Home() {
+  const today = new Date();
+  const currentMonth = formatMonth(today);
 
   return (
     <div className="flex min-h-screen w-full max-w-6xl self-start">
-      <CalendarProvider>
-        <TransactionProvider>
-          <Suspense fallback={<CalendarSkeleton />}>
-            <DataCalendar
-              startDate={startDate}
-              endDate={endDate}
-              currentMonth={currentMonth}
-              selectedDate={params.selected_date}
-              monthDate={monthDate}
-            />
-          </Suspense>
-        </TransactionProvider>
-      </CalendarProvider>
+      <Suspense fallback={<CalendarSkeleton />}>
+        <InitialDataLoader
+          currentMonth={currentMonth}
+        />
+      </Suspense>
     </div>
   );
 }
 
-async function DataCalendar({
-  startDate,
-  endDate,
-  currentMonth,
-}: {
-  startDate: string;
-  endDate: string;
-  currentMonth: string;
-  selectedDate?: string;
-  monthDate: Date;
-}) {
-  const transactions = await getCachedTransaction(startDate, endDate, true);
+async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
   const today = new Date();
-  const isCurrentMonth = currentMonth === formatMonth(today);
+  const currentMonthDate = new Date(today.getFullYear(), today.getMonth(), 1);
 
-  return (
-    <div className="flex w-full flex-col gap-3">
-      <Calendar currentMonth={currentMonth} transactions={transactions}>
-        <DailyRecData/>
-      </Calendar>
-    </div>
-  );
-}
-
-async function DailyRecData() {
-
-  const today = new Date();
-  const currentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
-  const { startDate, endDate } = getMonthRange(currentMonth);
+  // 당월 데이터 fetch
   const [transactions, budgets, fixedRules] = await Promise.all([
-    getCachedTransaction(startDate, endDate, true),
-    getCachedBudgets(currentMonth),
-    getCachedFixedRules(currentMonth),
+    getMonthTransactions(`${currentMonth}-01`),
+    fetchBudgetsServer(currentMonthDate),
+    fetchFixedRulesByMonthServer(currentMonthDate),
   ]);
 
   const budget = getTotalBudgetAmount(budgets);
-
   const fixedPlannedThisMonth = getFixedPlannedExpenseByMonth(
     fixedRules,
-    currentMonth
+    currentMonthDate
   );
 
+  // 소비패턴
   const lookbackDays = 56;
-
   const lookbackEndDateString = formatLocalDate(today);
   const lookbackStartDate = new Date(today);
   lookbackStartDate.setDate(lookbackStartDate.getDate() - (lookbackDays - 1));
@@ -160,12 +99,14 @@ async function DailyRecData() {
   );
 
   const dailyChartData = buildDailyRecChartData({
-    monthDate : currentMonth,
+    monthDate : currentMonthDate,
     transactions,
     today,
     budget,
     fixedPlannedThisMonth,
     spendingTransactions,
   });
+
+  // Calendar Client 생성 후 수정
   return <DailyRecBar daily={daily} dailyChartData={dailyChartData} />;
 }

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -70,49 +70,32 @@ async function DataCalendar({
   const transactions = await getTransaction(filters, true);
   const today = new Date();
   const isCurrentMonth = currentMonth === formatMonth(today);
-  if (!isCurrentMonth) {
-    return (
-      <div className="flex w-full flex-col gap-3">
-        <Calendar
-          currentMonth={currentMonth}
-          transactions={transactions}
-        ></Calendar>
-      </div>
-    );
-  }
 
   return (
     <div className="flex w-full flex-col gap-3">
       <Calendar currentMonth={currentMonth} transactions={transactions}>
-        <DailyRecData
-          transactions={transactions}
-          monthDate={monthDate}
-          today={today}
-        />
+        <DailyRecData/>
       </Calendar>
     </div>
   );
 }
 
-async function DailyRecData({
-  transactions,
-  monthDate,
-  today,
-}: {
-  transactions: Awaited<ReturnType<typeof getTransaction>>;
-  monthDate: Date;
-  today: Date;
-}) {
-  const [budgets, fixedRules] = await Promise.all([
-    fetchBudgetsServer(monthDate),
-    fetchFixedRulesByMonthServer(monthDate),
+async function DailyRecData() {
+
+  const today = new Date();
+  const currentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const { startDate, endDate } = getMonthRange(currentMonth);
+  const [transactions, budgets, fixedRules] = await Promise.all([
+    getTransaction({ start_date: startDate, end_date: endDate }, true),
+    fetchBudgetsServer(currentMonth),
+    fetchFixedRulesByMonthServer(currentMonth),
   ]);
 
   const budget = getTotalBudgetAmount(budgets);
 
   const fixedPlannedThisMonth = getFixedPlannedExpenseByMonth(
     fixedRules,
-    monthDate
+    currentMonth
   );
 
   const lookbackDays = 56;
@@ -167,7 +150,7 @@ async function DailyRecData({
   );
 
   const dailyChartData = buildDailyRecChartData({
-    monthDate,
+    monthDate : currentMonth,
     transactions,
     today,
     budget,

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -41,19 +41,18 @@ export default async function Home({ searchParams }: PageProps) {
 
   return (
     <div className="flex min-h-screen w-full max-w-6xl self-start">
-      <TransactionProvider>
-        <CalendarProvider>
-          <Suspense key={currentMonth} fallback={<CalendarSkeleton />}>
+      <CalendarProvider>
+        <TransactionProvider>
+          <Suspense fallback={<CalendarSkeleton />}>
             <DataCalendar
               filters={filters}
               currentMonth={currentMonth}
               selectedDate={params.selected_date}
               monthDate={monthDate}
             />
-            {/* <CalendarSkeleton /> */}
           </Suspense>
-        </CalendarProvider>
-      </TransactionProvider>
+        </TransactionProvider>
+      </CalendarProvider>
     </div>
   );
 }
@@ -61,7 +60,6 @@ export default async function Home({ searchParams }: PageProps) {
 async function DataCalendar({
   filters,
   currentMonth,
-  selectedDate,
   monthDate,
 }: {
   filters: TransactionFilters;
@@ -69,28 +67,53 @@ async function DataCalendar({
   selectedDate?: string;
   monthDate: Date;
 }) {
-  const [transactions, budgets, fixedRules] = await Promise.all([
-    getTransaction(filters, true),
+  const transactions = await getTransaction(filters, true);
+  const today = new Date();
+  const isCurrentMonth = currentMonth === formatMonth(today);
+  if (!isCurrentMonth) {
+    return (
+      <div className="flex w-full flex-col gap-3">
+        <Calendar
+          currentMonth={currentMonth}
+          transactions={transactions}
+        ></Calendar>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <Calendar currentMonth={currentMonth} transactions={transactions}>
+        <DailyRecData
+          transactions={transactions}
+          monthDate={monthDate}
+          today={today}
+        />
+      </Calendar>
+    </div>
+  );
+}
+
+async function DailyRecData({
+  transactions,
+  monthDate,
+  today,
+}: {
+  transactions: Awaited<ReturnType<typeof getTransaction>>;
+  monthDate: Date;
+  today: Date;
+}) {
+  const [budgets, fixedRules] = await Promise.all([
     fetchBudgetsServer(monthDate),
     fetchFixedRulesByMonthServer(monthDate),
   ]);
 
   const budget = getTotalBudgetAmount(budgets);
 
-  const today = new Date();
-  const isCurrentMonth = currentMonth === formatMonth(today);
-
   const fixedPlannedThisMonth = getFixedPlannedExpenseByMonth(
     fixedRules,
     monthDate
   );
-  if (!isCurrentMonth) {
-    return (
-      <div className="flex w-full flex-col gap-3">
-        <Calendar currentMonth={currentMonth} transactions={transactions} />
-      </div>
-    );
-  }
 
   const lookbackDays = 56;
 
@@ -151,12 +174,5 @@ async function DataCalendar({
     fixedPlannedThisMonth,
     spendingTransactions,
   });
-
-  return (
-    <div className="flex w-full flex-col gap-3">
-      <Calendar currentMonth={currentMonth} transactions={transactions}>
-        <DailyRecBar daily={daily} dailyChartData={dailyChartData} />
-      </Calendar>
-    </div>
-  );
+  return <DailyRecBar daily={daily} dailyChartData={dailyChartData} />;
 }

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -19,7 +19,20 @@ import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs';
 import { buildDailyRecChartData } from '@/services/daily-recommendation/chart';
 import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
 import { SpendingTransaction } from '@/services/daily-recommendation/spendingPattern';
+import { cache } from 'react';
 
+const getCachedTransaction = cache(
+  async (startDate: string, endDate: string, includeFixed: boolean) => {
+    return await getTransaction({ start_date: startDate, end_date: endDate }, includeFixed);
+  }
+);
+const getCachedBudgets = cache(async (monthDate: Date) => {
+  return await fetchBudgetsServer(monthDate);
+});
+
+const getCachedFixedRules = cache(async (monthDate: Date) => {
+  return await fetchFixedRulesByMonthServer(monthDate);
+});
 interface PageProps {
   searchParams: Promise<{
     month?: string;
@@ -34,18 +47,14 @@ export default async function Home({ searchParams }: PageProps) {
   const monthDate = new Date(`${currentMonth}-01`);
   const { startDate, endDate } = getMonthRange(monthDate);
 
-  const filters: TransactionFilters = {
-    start_date: startDate,
-    end_date: endDate,
-  };
-
   return (
     <div className="flex min-h-screen w-full max-w-6xl self-start">
       <CalendarProvider>
         <TransactionProvider>
           <Suspense fallback={<CalendarSkeleton />}>
             <DataCalendar
-              filters={filters}
+              startDate={startDate}
+              endDate={endDate}
               currentMonth={currentMonth}
               selectedDate={params.selected_date}
               monthDate={monthDate}
@@ -58,16 +67,17 @@ export default async function Home({ searchParams }: PageProps) {
 }
 
 async function DataCalendar({
-  filters,
+  startDate,
+  endDate,
   currentMonth,
-  monthDate,
 }: {
-  filters: TransactionFilters;
+  startDate: string;
+  endDate: string;
   currentMonth: string;
   selectedDate?: string;
   monthDate: Date;
 }) {
-  const transactions = await getTransaction(filters, true);
+  const transactions = await getCachedTransaction(startDate, endDate, true);
   const today = new Date();
   const isCurrentMonth = currentMonth === formatMonth(today);
 
@@ -86,9 +96,9 @@ async function DailyRecData() {
   const currentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
   const { startDate, endDate } = getMonthRange(currentMonth);
   const [transactions, budgets, fixedRules] = await Promise.all([
-    getTransaction({ start_date: startDate, end_date: endDate }, true),
-    fetchBudgetsServer(currentMonth),
-    fetchFixedRulesByMonthServer(currentMonth),
+    getCachedTransaction(startDate, endDate, true),
+    getCachedBudgets(currentMonth),
+    getCachedFixedRules(currentMonth),
   ]);
 
   const budget = getTotalBudgetAmount(budgets);

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -14,6 +14,7 @@ import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs';
 import { buildDailyRecChartData } from '@/services/daily-recommendation/chart';
 import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
 import { SpendingTransaction } from '@/services/daily-recommendation/spendingPattern';
+import { CalendarClient } from '@/components/calendar/CalendarClient';
 
 export default async function Home() {
   const today = new Date();
@@ -107,6 +108,12 @@ async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
     spendingTransactions,
   });
 
-  // Calendar Client 생성 후 수정
-  return <DailyRecBar daily={daily} dailyChartData={dailyChartData} />;
+  return (
+    <CalendarClient
+      currentMonth={currentMonth}
+      initialTransactions={transactions}
+      dailyRec={daily}
+      dailyChartData={dailyChartData}
+    />
+  )
 }

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -23,6 +23,7 @@ import { queryClient } from '@/stores/query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { CalendarSkeleton } from './CalendarSkeleton';
 import { CalendarDay } from './CalendarDay';
+import { useCalendarData } from '@/hooks/useCalendarData';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
@@ -53,52 +54,11 @@ export const Calendar = ({
   const [date, setDate] = useState<Date | undefined>(new Date());
   const { selectedDate, isOpen, open, close } = useCalendar();
   const [panelState, setPanelState] = useState<PanelState>({ view: 'list' });
+  const {groupedTransaction, TransactionSummary} = useCalendarData(transactions);
 
   useEffect(() => {
     setMonth(new Date(`${currentMonth}-01`));
   }, [currentMonth]);
-
-  const groupedTransaction = useMemo(() => {
-    const grouped: Record<string, DayData> = {};
-
-    transactions.forEach((transaction) => {
-      const dateKey = transaction.date;
-
-      if (!grouped[dateKey]) {
-        grouped[dateKey] = {
-          income: 0,
-          expense: 0,
-          transactions: [],
-        };
-      }
-
-      if (transaction.type === 'income') {
-        grouped[dateKey].income += transaction.amount;
-      } else if (transaction.type === 'expense') {
-        grouped[dateKey].expense += transaction.amount;
-      }
-
-      grouped[dateKey].transactions.push(transaction);
-    });
-
-    return grouped;
-  }, [transactions]);
-
-  const TransactionSummary = useMemo(() => {
-    const summary = transactions.reduce(
-      (acc, transaction) => {
-        if (transaction.type === 'income') {
-          acc.income += transaction.amount;
-        } else if (transaction.type === 'expense') {
-          acc.expense += transaction.amount;
-        }
-        return acc;
-      },
-      { income: 0, expense: 0 }
-    );
-
-    return summary;
-  }, [transactions]);
 
   const selectedDayTransactions = useMemo(() => {
     if (!selectedDate) return [];

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -25,6 +25,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { Spinner } from '../ui/spinner';
 
 interface CalendarProps {
   currentMonth: string;
@@ -230,6 +231,13 @@ export const Calendar = ({
   };
   return (
     <div className="flex w-full flex-col">
+      {isLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-2">
+            <Spinner className="text-brand h-12 w-12" />
+          </div>
+        </div>
+      )}
       <CalendarView
         month={month}
         mode="single"

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -24,8 +24,9 @@ import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
-  isLoading : boolean;
-  onMonthChange : (month:string)=> void;
+  isLoading: boolean;
+  onMonthChange: (month: string) => void;
+  children?: React.ReactNode;
 }
 interface DayData {
   income: number;
@@ -44,12 +45,14 @@ export const Calendar = ({
   currentMonth,
   transactions,
   isLoading,
-  onMonthChange
+  onMonthChange,
+  children,
 }: CalendarProps) => {
   const queryClient = useQueryClient();
   const { selectedDate, isOpen, open, close } = useCalendar();
   const [panelState, setPanelState] = useState<PanelState>({ view: 'list' });
-  const {groupedTransaction, TransactionSummary} = useCalendarData(transactions);
+  const { groupedTransaction, TransactionSummary } =
+    useCalendarData(transactions);
   const {
     month,
     date,
@@ -58,7 +61,7 @@ export const Calendar = ({
     displayMonth,
     handleMonthChange,
     moveMonth,
-  } = useCalendarNavigation(currentMonth,onMonthChange);
+  } = useCalendarNavigation(currentMonth, onMonthChange);
 
   const selectedDayTransactions = useMemo(() => {
     if (!selectedDate) return [];
@@ -74,8 +77,8 @@ export const Calendar = ({
     return <CalendarDay {...props} dayData={dayData} />;
   };
   const handleTransactionSuccess = async () => {
-    await queryClient.invalidateQueries({ 
-      queryKey: ['transactions', formatMonth(month)] 
+    await queryClient.invalidateQueries({
+      queryKey: ['transactions', formatMonth(month)],
     });
     setPanelState({ view: 'list' });
   };
@@ -87,52 +90,70 @@ export const Calendar = ({
     setPanelState({ view: 'list' });
   };
 
-  const CustomCaption = (props: MonthCaptionProps) => {
+  const CustomCaption = () => {
     return (
-      <div className="flex w-full gap-2 p-2 sm:flex-row sm:gap-4">
-        <Card className="w-full items-center gap-2">
-          <CardTitle className="text-xs sm:text-base">이번 달 수입</CardTitle>
-          <CardContent className="text-xs text-blue-600 sm:text-base">
-            {income.toLocaleString()}원
-          </CardContent>
-        </Card>
-        <Card className="w-full items-center gap-2">
-          <CardTitle className="text-xs sm:text-base">이번 달 지출</CardTitle>
-          <CardContent className="text-xs text-red-600 sm:text-base">
-            {expense.toLocaleString()}원
-          </CardContent>
-        </Card>
+      <div className="mb-4 w-full">
+        <div className="flex flex-col-reverse gap-2 sm:flex-row">
+          <div
+            className={cn(
+              'flex items-center justify-between rounded-md px-4 py-3 sm:flex-1',
+              'bg-brand-subtle dark:bg-muted/40',
+              'dark:border-border border border-transparent',
+              'border-l-brand border-l-4'
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hover:bg-brand-soft/40 h-8 w-8"
+                onClick={() => moveMonth(-1)}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+
+              <span className="text-xl font-semibold tracking-tight sm:text-2xl">
+                {displayMonth}월
+              </span>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hover:bg-brand-soft/40 h-8 w-8"
+                onClick={() => moveMonth(1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="space-y-1 text-right">
+              <div className="flex items-baseline justify-end gap-2">
+                <span className="text-muted-foreground text-xs font-medium sm:text-sm">
+                  수입
+                </span>
+                <span className="text-sm font-semibold tracking-tight text-blue-500 sm:text-base">
+                  {income.toLocaleString()}원
+                </span>
+              </div>
+
+              <div className="flex items-baseline justify-end gap-2">
+                <span className="text-muted-foreground text-xs font-medium sm:text-sm">
+                  지출
+                </span>
+                <span className="text-sm font-semibold tracking-tight text-red-400 sm:text-base">
+                  {expense.toLocaleString()}원
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {children}
+        </div>
       </div>
     );
   };
   return (
-    <div className="flex w-full flex-col items-center">
-      <div className="flex flex-col items-center justify-center py-3 md:py-6">
-        <span className="text-muted-foreground text-sm font-bold md:text-base">
-          {year}
-        </span>
-        <div className="flex items-center justify-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="cursor-pointer"
-            onClick={() => moveMonth(-1)}
-          >
-            <ChevronLeft />
-          </Button>
-
-          <span className="text-2xl font-bold">{displayMonth}월</span>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            className="cursor-pointer"
-            onClick={() => moveMonth(1)}
-          >
-            <ChevronRight />
-          </Button>
-        </div>
-      </div>
+    <div className="flex w-full flex-col">
       <CalendarView
         month={month}
         mode="single"

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -122,7 +122,7 @@ export const Calendar = ({
         <div className="flex flex-col-reverse gap-2 sm:flex-row">
           <div
             className={cn(
-              'flex items-center justify-between rounded-md px-4 py-3 sm:flex-1',
+              'flex flex-2 items-center justify-between rounded-md px-4 py-3 sm:flex-1',
               'bg-brand-subtle dark:bg-muted/40',
               'dark:border-border border border-transparent',
               'border-l-brand border-l-4'
@@ -145,7 +145,7 @@ export const Calendar = ({
                     <Button
                       variant="ghost"
                       className={cn(
-                        'hover:bg-brand-soft/40 w-10 justify-center font-semibold',
+                        'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
                         'text-xl tracking-tight sm:text-2xl'
                       )}
                     >
@@ -224,7 +224,7 @@ export const Calendar = ({
             </div>
           </div>
 
-          {children}
+          <div className="flex-1">{children}</div>
         </div>
       </div>
     );

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -20,6 +20,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { CalendarDay } from './CalendarDay';
 import { useCalendarData } from '@/hooks/useCalendarData';
 import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 
 interface CalendarProps {
   currentMonth: string;
@@ -37,7 +42,10 @@ interface PanelState {
   view: 'list' | 'create' | 'edit';
   editingTransaction?: ITransaction;
 }
-
+const MONTHS = Array.from({ length: 12 }, (_, i) => ({
+  month: i + 1,
+  monthDisplay: `${i + 1}월`,
+}));
 const CALENDAR_CELL_HEIGHT =
   '[&_td]:!h-[50px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
 
@@ -61,6 +69,7 @@ export const Calendar = ({
     displayMonth,
     handleMonthChange,
     moveMonth,
+    navigateMonth,
   } = useCalendarNavigation(currentMonth, onMonthChange);
 
   const selectedDayTransactions = useMemo(() => {
@@ -91,6 +100,22 @@ export const Calendar = ({
   };
 
   const CustomCaption = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [mode, setMode] = useState<'month' | 'year'>('month');
+    const handleMonthSelect = (selectedDate: Date | undefined) => {
+      if (selectedDate) {
+        handleMonthChange(selectedDate);
+        setIsOpen(false);
+      }
+    };
+    const currentYear = new Date().getFullYear();
+    const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
+
+    const handleYearSelect = (selectedYear: number) => {
+      const newDate = new Date(selectedYear, month.getMonth(), 1);
+      handleMonthChange(newDate);
+      setMode('month');
+    };
     return (
       <div className="mb-4 w-full">
         <div className="flex flex-col-reverse gap-2 sm:flex-row">
@@ -102,30 +127,81 @@ export const Calendar = ({
               'border-l-brand border-l-4'
             )}
           >
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-brand-soft/40 h-8 w-8"
-                onClick={() => moveMonth(-1)}
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
+            <div className="flex flex-col items-center">
+              <span className="text-muted-foreground text-xs">{year}</span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hover:bg-brand-soft/40 h-8 w-8"
+                  onClick={() => moveMonth(-1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
 
-              <span className="text-xl font-semibold tracking-tight sm:text-2xl">
-                {displayMonth}월
-              </span>
+                <Popover open={isOpen} onOpenChange={setIsOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className={cn(
+                        'hover:bg-brand-soft/40 w-10 justify-center font-semibold',
+                        'text-xl tracking-tight sm:text-2xl'
+                      )}
+                    >
+                      {displayMonth}월
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    {mode === 'month' ? (
+                      <div className="grid grid-cols-3">
+                        <div
+                          onClick={() => setMode('year')}
+                          className="col-span-3 cursor-pointer p-2 text-center font-bold hover:bg-gray-100"
+                        >
+                          {year}
+                        </div>
+                        {MONTHS.map(({ month, monthDisplay }) => (
+                          <div
+                            className="flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 text-center text-xs hover:bg-gray-100"
+                            onClick={() => navigateMonth(month)}
+                            key={month}
+                          >
+                            {monthDisplay}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-3 p-2">
+                        <div
+                          className="col-span-3 cursor-pointer p-2 text-center font-bold hover:bg-gray-100"
+                          onClick={() => setMode('month')}
+                        >
+                          {displayMonth}월
+                        </div>
+                        {years.map((y) => (
+                          <div
+                            key={y}
+                            className="flex h-12 w-12 cursor-pointer items-center justify-center text-sm hover:bg-gray-100"
+                            onClick={() => handleYearSelect(y)}
+                          >
+                            {y}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </PopoverContent>
+                </Popover>
 
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-brand-soft/40 h-8 w-8"
-                onClick={() => moveMonth(1)}
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hover:bg-brand-soft/40 h-8 w-8"
+                  onClick={() => moveMonth(1)}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
-
             <div className="space-y-1 text-right">
               <div className="flex items-baseline justify-end gap-2">
                 <span className="text-muted-foreground text-xs font-medium sm:text-sm">

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -22,7 +22,6 @@ import { Item, ItemContent } from '../ui/item';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
-  children?: ReactNode;
 }
 
 interface DayData {
@@ -91,7 +90,6 @@ const CustomDay = ({
 export const Calendar = ({
   currentMonth,
   transactions,
-  children,
 }: CalendarProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -231,7 +229,6 @@ export const Calendar = ({
           </Button>
         </div>
       </div>
-      <div className="w-full">{children}</div>
       <CalendarView
         month={month}
         mode="single"

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -9,8 +9,6 @@ import { useCalendar } from '@/context/CalendarContext';
 import { ITransaction } from '@/types/transactions';
 import { useMemo } from 'react';
 import { formatDateKR, formatLocalDate } from '@/utils/date';
-import { Card, CardTitle, CardContent } from '../ui/card';
-import { MonthCaptionProps } from 'react-day-picker';
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
 import { TransactionList } from '../transaction/TransactionList';
 import { formatMonth } from '@/utils/date';
@@ -20,12 +18,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { CalendarDay } from './CalendarDay';
 import { useCalendarData } from '@/hooks/useCalendarData';
 import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
 import { Spinner } from '../ui/spinner';
+import { CalendarCaption } from './CalendarCaption';
 
 interface CalendarProps {
   currentMonth: string;
@@ -34,19 +28,10 @@ interface CalendarProps {
   onMonthChange: (month: string) => void;
   children?: React.ReactNode;
 }
-interface DayData {
-  income: number;
-  expense: number;
-  transactions: ITransaction[];
-}
 interface PanelState {
   view: 'list' | 'create' | 'edit';
   editingTransaction?: ITransaction;
 }
-const MONTHS = Array.from({ length: 12 }, (_, i) => ({
-  month: i + 1,
-  monthDisplay: `${i + 1}월`,
-}));
 const CALENDAR_CELL_HEIGHT =
   '[&_td]:!h-[50px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
 
@@ -100,135 +85,22 @@ export const Calendar = ({
     setPanelState({ view: 'list' });
   };
 
-  const CustomCaption = () => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [mode, setMode] = useState<'month' | 'year'>('month');
-    const handleMonthSelect = (selectedDate: Date | undefined) => {
-      if (selectedDate) {
-        handleMonthChange(selectedDate);
-        setIsOpen(false);
-      }
-    };
-    const currentYear = new Date().getFullYear();
-    const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
-
-    const handleYearSelect = (selectedYear: number) => {
-      const newDate = new Date(selectedYear, month.getMonth(), 1);
-      handleMonthChange(newDate);
-      setMode('month');
-    };
-    return (
-      <div className="mb-4 w-full">
-        <div className="flex flex-col-reverse gap-2 sm:flex-row">
-          <div
-            className={cn(
-              'flex items-center justify-between rounded-md px-4 py-3 sm:flex-1',
-              'bg-brand-subtle dark:bg-muted/40',
-              'dark:border-border border border-transparent',
-              'border-l-brand border-l-4'
-            )}
-          >
-            <div className="flex flex-col items-center">
-              <span className="text-muted-foreground text-xs">{year}</span>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="hover:bg-brand-soft/40 h-8 w-8"
-                  onClick={() => moveMonth(-1)}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-
-                <Popover open={isOpen} onOpenChange={setIsOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      className={cn(
-                        'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
-                        'text-xl tracking-tight sm:text-2xl'
-                      )}
-                    >
-                      {displayMonth}월
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    {mode === 'month' ? (
-                      <div className="grid grid-cols-3 p-2">
-                        <div
-                          onClick={() => setMode('year')}
-                          className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer p-2 text-center font-bold"
-                        >
-                          {year}
-                        </div>
-                        {MONTHS.map(({ month, monthDisplay }) => (
-                          <div
-                            className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 text-center text-xs"
-                            onClick={() => navigateMonth(month)}
-                            key={month}
-                          >
-                            {monthDisplay}
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="grid grid-cols-3 p-2">
-                        <div
-                          className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer p-2 text-center font-bold"
-                          onClick={() => setMode('month')}
-                        >
-                          {displayMonth}월
-                        </div>
-                        {years.map((y) => (
-                          <div
-                            key={y}
-                            className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer items-center justify-center text-sm"
-                            onClick={() => handleYearSelect(y)}
-                          >
-                            {y}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </PopoverContent>
-                </Popover>
-
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="hover:bg-brand-soft/40 h-8 w-8"
-                  onClick={() => moveMonth(1)}
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-            <div className="space-y-1 text-right">
-              <div className="flex items-baseline justify-end gap-2">
-                <span className="text-muted-foreground text-xs font-medium sm:text-sm">
-                  수입
-                </span>
-                <span className="text-sm font-semibold tracking-tight text-blue-500 sm:text-base">
-                  {income.toLocaleString()}원
-                </span>
-              </div>
-
-              <div className="flex items-baseline justify-end gap-2">
-                <span className="text-muted-foreground text-xs font-medium sm:text-sm">
-                  지출
-                </span>
-                <span className="text-sm font-semibold tracking-tight text-red-400 sm:text-base">
-                  {expense.toLocaleString()}원
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex-1">{children}</div>
-        </div>
-      </div>
-    );
-  };
+  const CustomCaption = () => (
+    <>
+      <CalendarCaption
+        year={year}
+        displayMonth={displayMonth}
+        month={month}
+        income={income}
+        expense={expense}
+        moveMonth={moveMonth}
+        navigateMonth={navigateMonth}
+        handleMonthChange={handleMonthChange}
+      >
+        {children}
+      </CalendarCaption>
+    </>
+  );
   return (
     <div className="flex w-full flex-col">
       {isLoading && (

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -24,6 +24,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { CalendarSkeleton } from './CalendarSkeleton';
 import { CalendarDay } from './CalendarDay';
 import { useCalendarData } from '@/hooks/useCalendarData';
+import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
@@ -50,15 +51,18 @@ export const Calendar = ({
   onMonthChange
 }: CalendarProps) => {
   const queryClient = useQueryClient();
-  const [month, setMonth] = useState<Date>(new Date(`${currentMonth}-01`));
-  const [date, setDate] = useState<Date | undefined>(new Date());
   const { selectedDate, isOpen, open, close } = useCalendar();
   const [panelState, setPanelState] = useState<PanelState>({ view: 'list' });
   const {groupedTransaction, TransactionSummary} = useCalendarData(transactions);
-
-  useEffect(() => {
-    setMonth(new Date(`${currentMonth}-01`));
-  }, [currentMonth]);
+  const {
+    month,
+    date,
+    setDate,
+    year,
+    displayMonth,
+    handleMonthChange,
+    moveMonth,
+  } = useCalendarNavigation(currentMonth,onMonthChange);
 
   const selectedDayTransactions = useMemo(() => {
     if (!selectedDate) return [];
@@ -73,17 +77,6 @@ export const Calendar = ({
 
     return <CalendarDay {...props} dayData={dayData} />;
   };
-
-  const handleMonthChange = (newMonth: Date) => {
-    setMonth(newMonth);
-    const monthString = formatMonth(newMonth);
-    onMonthChange(monthString);
-  };
-
-  const moveMonth = (offset: number) => {
-    const newDate = new Date(month.getFullYear(), month.getMonth() + offset, 1);
-    handleMonthChange(newDate);
-  };
   const handleTransactionSuccess = async () => {
     await queryClient.invalidateQueries({ 
       queryKey: ['transactions', formatMonth(month)] 
@@ -92,9 +85,6 @@ export const Calendar = ({
   };
 
   const { income, expense } = TransactionSummary;
-
-  const year = month.getFullYear();
-  const displayMonth = month.getMonth() + 1;
 
   const handleClose = () => {
     close();

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -122,7 +122,7 @@ export const Calendar = ({
         <div className="flex flex-col-reverse gap-2 sm:flex-row">
           <div
             className={cn(
-              'flex flex-2 items-center justify-between rounded-md px-4 py-3 sm:flex-1',
+              'flex items-center justify-between rounded-md px-4 py-3 sm:flex-1',
               'bg-brand-subtle dark:bg-muted/40',
               'dark:border-border border border-transparent',
               'border-l-brand border-l-4'
@@ -154,16 +154,16 @@ export const Calendar = ({
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0" align="start">
                     {mode === 'month' ? (
-                      <div className="grid grid-cols-3">
+                      <div className="grid grid-cols-3 p-2">
                         <div
                           onClick={() => setMode('year')}
-                          className="col-span-3 cursor-pointer p-2 text-center font-bold hover:bg-gray-100"
+                          className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer p-2 text-center font-bold"
                         >
                           {year}
                         </div>
                         {MONTHS.map(({ month, monthDisplay }) => (
                           <div
-                            className="flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 text-center text-xs hover:bg-gray-100"
+                            className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 text-center text-xs"
                             onClick={() => navigateMonth(month)}
                             key={month}
                           >
@@ -174,7 +174,7 @@ export const Calendar = ({
                     ) : (
                       <div className="grid grid-cols-3 p-2">
                         <div
-                          className="col-span-3 cursor-pointer p-2 text-center font-bold hover:bg-gray-100"
+                          className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer p-2 text-center font-bold"
                           onClick={() => setMode('month')}
                         >
                           {displayMonth}월
@@ -182,7 +182,7 @@ export const Calendar = ({
                         {years.map((y) => (
                           <div
                             key={y}
-                            className="flex h-12 w-12 cursor-pointer items-center justify-center text-sm hover:bg-gray-100"
+                            className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer items-center justify-center text-sm"
                             onClick={() => handleYearSelect(y)}
                           >
                             {y}

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -19,9 +19,13 @@ import { formatMonth } from '@/utils/date';
 import TransactionSubmitForm from '../transaction/TransactionSubmitForm';
 import { revalidateTransactions } from '@/app/(app)/history/actions';
 import { Item, ItemContent } from '../ui/item';
+import { queryClient } from '@/stores/query-client';
+import { useQueryClient } from '@tanstack/react-query';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
+  isLoading : boolean;
+  onMonthChange : (month:string)=> void;
 }
 
 interface DayData {
@@ -90,14 +94,13 @@ const CustomDay = ({
 export const Calendar = ({
   currentMonth,
   transactions,
+  isLoading,
+  onMonthChange
 }: CalendarProps) => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
+  const queryClient = useQueryClient();
   const [month, setMonth] = useState<Date>(new Date(`${currentMonth}-01`));
   const [date, setDate] = useState<Date | undefined>(new Date());
   const { selectedDate, isOpen, open, close } = useCalendar();
-
   const [panelState, setPanelState] = useState<PanelState>({ view: 'list' });
 
   useEffect(() => {
@@ -162,16 +165,19 @@ export const Calendar = ({
 
   const handleMonthChange = (newMonth: Date) => {
     setMonth(newMonth);
-
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('month', formatMonth(newMonth));
-
-    router.push(`?${params.toString()}`);
+    const monthString = formatMonth(newMonth);
+    onMonthChange(monthString);
   };
 
   const moveMonth = (offset: number) => {
     const newDate = new Date(month.getFullYear(), month.getMonth() + offset, 1);
     handleMonthChange(newDate);
+  };
+  const handleTransactionSuccess = async () => {
+    await queryClient.invalidateQueries({ 
+      queryKey: ['transactions', formatMonth(month)] 
+    });
+    setPanelState({ view: 'list' });
   };
 
   const { income, expense } = TransactionSummary;
@@ -183,6 +189,7 @@ export const Calendar = ({
     close();
     setPanelState({ view: 'list' });
   };
+
   const CustomCaption = (props: MonthCaptionProps) => {
     return (
       <div className="flex w-full gap-2 p-2 sm:flex-row sm:gap-4">
@@ -294,10 +301,7 @@ export const Calendar = ({
               </Button>
               <TransactionSubmitForm
                 transaction={panelState.editingTransaction}
-                onSuccess={async () => {
-                  await revalidateTransactions();
-                  setPanelState({ view: 'list' });
-                }}
+                onSuccess={handleTransactionSuccess}
                 onClose={() => {
                   setPanelState({ view: 'list' });
                 }}
@@ -319,10 +323,7 @@ export const Calendar = ({
               </Button>
               <TransactionSubmitForm
                 defaultDate={selectedDate ?? undefined}
-                onSuccess={async () => {
-                  await revalidateTransactions();
-                  setPanelState({ view: 'list' });
-                }}
+                onSuccess={handleTransactionSuccess}
                 onClose={() => {
                   setPanelState({ view: 'list' });
                 }}

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -21,13 +21,14 @@ import { revalidateTransactions } from '@/app/(app)/history/actions';
 import { Item, ItemContent } from '../ui/item';
 import { queryClient } from '@/stores/query-client';
 import { useQueryClient } from '@tanstack/react-query';
+import { CalendarSkeleton } from './CalendarSkeleton';
+import { CalendarDay } from './CalendarDay';
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
   isLoading : boolean;
   onMonthChange : (month:string)=> void;
 }
-
 interface DayData {
   income: number;
   expense: number;
@@ -40,56 +41,6 @@ interface PanelState {
 
 const CALENDAR_CELL_HEIGHT =
   '[&_td]:!h-[50px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
-
-const CustomDay = ({
-  day,
-  modifiers,
-  dayData,
-  ...props
-}: React.ComponentProps<typeof DayButton> & { dayData?: DayData }) => {
-  const ref = useRef<HTMLButtonElement>(null);
-  const defaultClassNames = getDefaultClassNames();
-  useEffect(() => {
-    if (modifiers.focused) ref.current?.focus();
-  }, [modifiers.focused]);
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      data-day={formatLocalDate(day.date)}
-      data-selected-single={modifiers.selected}
-      {...props}
-      className={cn(
-        'flex flex-col items-center justify-start gap-1',
-        'aspect-square h-full w-full',
-        'p-0.5 sm:p-2 sm:pt-1',
-        'gap-0 sm:gap-1',
-        CALENDAR_CELL_HEIGHT,
-        defaultClassNames.day
-      )}
-    >
-      <div className="flex flex-col gap-0.5 sm:gap-0.5 md:gap-1">
-        <span className="text-sm font-medium sm:text-base md:text-lg">
-          {day.date.getDate()}
-        </span>
-        {dayData && (dayData.income > 0 || dayData.expense > 0) && (
-          <div className="flex flex-col text-[7px] sm:text-[10px] md:text-xs">
-            {dayData.income > 0 && (
-              <span className="text-blue-500">
-                +{dayData.income.toLocaleString()}
-              </span>
-            )}
-            {dayData.expense > 0 && (
-              <span className="text-red-500">
-                -{dayData.expense.toLocaleString()}
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-    </Button>
-  );
-};
 
 export const Calendar = ({
   currentMonth,
@@ -160,7 +111,7 @@ export const Calendar = ({
     const dateKey = formatLocalDate(props.day.date);
     const dayData = groupedTransaction[dateKey];
 
-    return <CustomDay {...props} dayData={dayData} />;
+    return <CalendarDay {...props} dayData={dayData} />;
   };
 
   const handleMonthChange = (newMonth: Date) => {

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -1,15 +1,13 @@
 'use client';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, useEffect, useRef, ReactNode } from 'react';
+import { useState } from 'react';
 import { Calendar as CalendarView } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
-import { Day, type DayButton, getDefaultClassNames } from 'react-day-picker';
+import { type DayButton } from 'react-day-picker';
 import { Button } from '../ui/button';
 import ResponsivePanel from '../panel/ResponsivePanel';
 import { useCalendar } from '@/context/CalendarContext';
 import { ITransaction } from '@/types/transactions';
 import { useMemo } from 'react';
-import { CaptionLabelProps } from 'react-day-picker';
 import { formatDateKR, formatLocalDate } from '@/utils/date';
 import { Card, CardTitle, CardContent } from '../ui/card';
 import { MonthCaptionProps } from 'react-day-picker';
@@ -17,14 +15,12 @@ import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
 import { TransactionList } from '../transaction/TransactionList';
 import { formatMonth } from '@/utils/date';
 import TransactionSubmitForm from '../transaction/TransactionSubmitForm';
-import { revalidateTransactions } from '@/app/(app)/history/actions';
 import { Item, ItemContent } from '../ui/item';
-import { queryClient } from '@/stores/query-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { CalendarSkeleton } from './CalendarSkeleton';
 import { CalendarDay } from './CalendarDay';
 import { useCalendarData } from '@/hooks/useCalendarData';
 import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
+
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];

--- a/fe/src/components/calendar/CalendarCaption.tsx
+++ b/fe/src/components/calendar/CalendarCaption.tsx
@@ -1,27 +1,166 @@
-'use client'
+'use client';
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
 
-import { MonthCaptionProps } from "react-day-picker";
-import { Card, CardTitle,CardContent } from "../ui/card";
+const MONTHS = Array.from({ length: 12 }, (_, i) => ({
+  month: i + 1,
+  monthDisplay: `${i + 1}월`,
+}));
 
-interface CalendarCaptionProps extends MonthCaptionProps{
-      income : number;
-      expense: number;
+interface CalendarCaptionProps {
+  year: number;
+  displayMonth: number;
+  month: Date;
+  income: number;
+  expense: number;
+  moveMonth: (delta: number) => void;
+  navigateMonth: (month: number) => void;
+  handleMonthChange: (date: Date) => void;
+  children?: React.ReactNode;
 }
-const CalendarCaption = ({income, expense}: CalendarCaptionProps) => {
-    return (
-      <div className="flex w-full gap-2 p-2 sm:flex-row sm:gap-4">
-        <Card className="w-full items-center gap-2">
-          <CardTitle className="text-xs sm:text-base">이번 달 수입</CardTitle>
-          <CardContent className="text-xs text-blue-600 sm:text-base">
-            {income.toLocaleString()}원
-          </CardContent>
-        </Card>
-        <Card className="w-full items-center gap-2">
-          <CardTitle className="text-xs sm:text-base">이번 달 지출</CardTitle>
-          <CardContent className="text-xs text-red-600 sm:text-base">
-            {expense.toLocaleString()}원
-          </CardContent>
-        </Card>
-      </div>
-    );
+
+export const CalendarCaption = ({
+  year,
+  displayMonth,
+  month,
+  income,
+  expense,
+  moveMonth,
+  navigateMonth,
+  handleMonthChange,
+  children,
+}: CalendarCaptionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<'month' | 'year'>('month');
+
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
+
+  const handleYearSelect = (selectedYear: number) => {
+    const newDate = new Date(selectedYear, month.getMonth(), 1);
+    handleMonthChange(newDate);
+    setMode('month');
   };
+
+  return (
+    <div className="mb-4 w-full">
+      <div className="flex flex-col-reverse gap-2 lg:flex-row">
+        <div
+          className={cn(
+            'flex flex-1 items-center justify-between rounded-md px-4 py-3',
+            'bg-brand-subtle dark:bg-muted/40',
+            'dark:border-border border border-transparent',
+            'border-l-brand border-l-4'
+          )}
+        >
+          <div className="flex flex-col items-center">
+            <span className="text-muted-foreground text-xs">{year}</span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hover:bg-brand-soft/40 h-8 w-8"
+                onClick={() => moveMonth(-1)}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+
+              <Popover open={isOpen} onOpenChange={setIsOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className={cn(
+                      'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
+                      'text-xl tracking-tight sm:text-2xl'
+                    )}
+                  >
+                    {displayMonth}월
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  {mode === 'month' ? (
+                    <div className="grid grid-cols-3 p-2">
+                      <div
+                        onClick={() => setMode('year')}
+                        className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
+                      >
+                        {year}
+                      </div>
+                      {MONTHS.map(({ month, monthDisplay }) => (
+                        <div
+                          className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 rounded text-center text-xs"
+                          onClick={() => {
+                            navigateMonth(month);
+                            setIsOpen(false);
+                          }}
+                          key={month}
+                        >
+                          {monthDisplay}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-3 p-2">
+                      <div
+                        className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
+                        onClick={() => setMode('month')}
+                      >
+                        {displayMonth}월
+                      </div>
+                      {years.map((y) => (
+                        <div
+                          key={y}
+                          className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer items-center justify-center rounded text-sm"
+                          onClick={() => handleYearSelect(y)}
+                        >
+                          {y}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </PopoverContent>
+              </Popover>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hover:bg-brand-soft/40 h-8 w-8"
+                onClick={() => moveMonth(1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+          <div className="space-y-1 text-right">
+            <div className="flex items-baseline justify-end gap-2">
+              <span className="text-muted-foreground text-xs font-medium sm:text-sm">
+                수입
+              </span>
+              <span className="text-sm font-semibold tracking-tight text-blue-500 sm:text-base">
+                {income.toLocaleString()}원
+              </span>
+            </div>
+
+            <div className="flex items-baseline justify-end gap-2">
+              <span className="text-muted-foreground text-xs font-medium sm:text-sm">
+                지출
+              </span>
+              <span className="text-sm font-semibold tracking-tight text-red-400 sm:text-base">
+                {expense.toLocaleString()}원
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-2">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/fe/src/components/calendar/CalendarCaption.tsx
+++ b/fe/src/components/calendar/CalendarCaption.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { MonthCaptionProps } from "react-day-picker";
+import { Card, CardTitle,CardContent } from "../ui/card";
+
+interface CalendarCaptionProps extends MonthCaptionProps{
+      income : number;
+      expense: number;
+}
+const CalendarCaption = ({income, expense}: CalendarCaptionProps) => {
+    return (
+      <div className="flex w-full gap-2 p-2 sm:flex-row sm:gap-4">
+        <Card className="w-full items-center gap-2">
+          <CardTitle className="text-xs sm:text-base">이번 달 수입</CardTitle>
+          <CardContent className="text-xs text-blue-600 sm:text-base">
+            {income.toLocaleString()}원
+          </CardContent>
+        </Card>
+        <Card className="w-full items-center gap-2">
+          <CardTitle className="text-xs sm:text-base">이번 달 지출</CardTitle>
+          <CardContent className="text-xs text-red-600 sm:text-base">
+            {expense.toLocaleString()}원
+          </CardContent>
+        </Card>
+      </div>
+    );
+  };

--- a/fe/src/components/calendar/CalendarClient.tsx
+++ b/fe/src/components/calendar/CalendarClient.tsx
@@ -33,13 +33,14 @@ export function CalendarClient({
     <CalendarProvider>
       <TransactionProvider>
         <div className="flex w-full flex-col gap-3">
-          <DailyRecBar daily={dailyRec} dailyChartData={dailyChartData} />
           <Calendar
             currentMonth={month}
             transactions={transactions || []}
             isLoading={isLoading}
             onMonthChange={setMonth}
-          />
+          >
+            <DailyRecBar daily={dailyRec} dailyChartData={dailyChartData} />
+          </Calendar>
         </div>
       </TransactionProvider>
     </CalendarProvider>

--- a/fe/src/components/calendar/CalendarClient.tsx
+++ b/fe/src/components/calendar/CalendarClient.tsx
@@ -33,14 +33,12 @@ export function CalendarClient({
     <CalendarProvider>
       <TransactionProvider>
         <div className="flex w-full flex-col gap-3">
-          {month === currentMonth && (
-            <DailyRecBar daily={dailyRec} dailyChartData={dailyChartData} />
-          )}
-          
+          <DailyRecBar daily={dailyRec} dailyChartData={dailyChartData} />
           <Calendar
             currentMonth={month}
             transactions={transactions || []}
-            // loading state, month setState 추가
+            isLoading={isLoading}
+            onMonthChange={setMonth}
           />
         </div>
       </TransactionProvider>

--- a/fe/src/components/calendar/CalendarClient.tsx
+++ b/fe/src/components/calendar/CalendarClient.tsx
@@ -7,12 +7,12 @@ import { TransactionProvider } from '@/app/(app)/history/TransactionContext';
 import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 import { useMonthTransactions } from '@/hooks/useMonthTransactions';
 import { ITransaction } from '@/types/transactions';
-
+import { DailyRecResult, DailyRecChartData } from '@/types/dailyRec';
 interface CalendarClientProps {
   currentMonth: string;
   initialTransactions: ITransaction[];
-  dailyRec: any;
-  dailyChartData: any;
+  dailyRec: DailyRecResult;
+  dailyChartData: DailyRecChartData;
 }
 
 export function CalendarClient({

--- a/fe/src/components/calendar/CalendarClient.tsx
+++ b/fe/src/components/calendar/CalendarClient.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { Calendar } from './Calendar';
+import { CalendarProvider } from '@/context/CalendarContext';
+import { TransactionProvider } from '@/app/(app)/history/TransactionContext';
+import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
+import { useMonthTransactions } from '@/hooks/useMonthTransactions';
+import { ITransaction } from '@/types/transactions';
+
+interface CalendarClientProps {
+  currentMonth: string;
+  initialTransactions: ITransaction[];
+  dailyRec: any;
+  dailyChartData: any;
+}
+
+export function CalendarClient({
+  currentMonth,
+  initialTransactions,
+  dailyRec,
+  dailyChartData,
+}: CalendarClientProps) {
+  const [month, setMonth] = useState(currentMonth);
+
+  const { data: transactions, isLoading } = useMonthTransactions({
+    month,
+    currentMonth,
+    initialTransactions,
+  });
+
+  return (
+    <CalendarProvider>
+      <TransactionProvider>
+        <div className="flex w-full flex-col gap-3">
+          {month === currentMonth && (
+            <DailyRecBar daily={dailyRec} dailyChartData={dailyChartData} />
+          )}
+          
+          <Calendar
+            currentMonth={month}
+            transactions={transactions || []}
+            // loading state, month setState 추가
+          />
+        </div>
+      </TransactionProvider>
+    </CalendarProvider>
+  );
+}

--- a/fe/src/components/calendar/CalendarDay.tsx
+++ b/fe/src/components/calendar/CalendarDay.tsx
@@ -1,0 +1,65 @@
+import { Button } from "../ui/button";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { formatLocalDate } from "@/utils/date";
+import { type DayButton, getDefaultClassNames } from 'react-day-picker';
+import { ITransaction } from "@/types/transactions";
+
+interface DayData {
+  income: number;
+  expense: number;
+  transactions: ITransaction[];
+}
+
+const CALENDAR_CELL_HEIGHT =
+  '[&_td]:!h-[50px] sm:[&_td]:!h-[70px] md:[&_td]:!h-[80px]';
+
+export const CalendarDay = ({
+  day,
+  modifiers,
+  dayData,
+  ...props
+}: React.ComponentProps<typeof DayButton> & { dayData?: DayData }) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const defaultClassNames = getDefaultClassNames();
+  useEffect(() => {
+    if (modifiers.focused) ref.current?.focus();
+  }, [modifiers.focused]);
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      data-day={formatLocalDate(day.date)}
+      data-selected-single={modifiers.selected}
+      {...props}
+      className={cn(
+        'flex flex-col items-center justify-start gap-1',
+        'aspect-square h-full w-full',
+        'p-0.5 sm:p-2 sm:pt-1',
+        'gap-0 sm:gap-1',
+        CALENDAR_CELL_HEIGHT,
+        defaultClassNames.day
+      )}
+    >
+      <div className="flex flex-col gap-0.5 sm:gap-0.5 md:gap-1">
+        <span className="text-sm font-medium sm:text-base md:text-lg">
+          {day.date.getDate()}
+        </span>
+        {dayData && (dayData.income > 0 || dayData.expense > 0) && (
+          <div className="flex flex-col text-[7px] sm:text-[10px] md:text-xs">
+            {dayData.income > 0 && (
+              <span className="text-blue-500">
+                +{dayData.income.toLocaleString()}
+              </span>
+            )}
+            {dayData.expense > 0 && (
+              <span className="text-red-500">
+                -{dayData.expense.toLocaleString()}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </Button>
+  );
+};

--- a/fe/src/components/daily-recommendation/DailyRecBar.tsx
+++ b/fe/src/components/daily-recommendation/DailyRecBar.tsx
@@ -16,7 +16,7 @@ export const DailyRecBar = ({ daily, dailyChartData }: Props) => {
   return (
     <div
       className={cn(
-        'flex items-center justify-between rounded-md px-4 py-3',
+        'flex h-full items-center justify-between rounded-md px-4 py-3',
         'bg-brand-subtle dark:bg-muted/40',
         'dark:border-border border border-transparent',
         'border-l-brand border-l-4'

--- a/fe/src/hooks/useCalendarData.ts
+++ b/fe/src/hooks/useCalendarData.ts
@@ -1,0 +1,55 @@
+'use client'
+import { useMemo } from "react"
+import { ITransaction } from "@/types/transactions"
+import { formatLocalDate } from "@/utils/date"
+interface DayData{
+      income : number;
+      expense : number;
+      transactions : ITransaction[];
+}
+export const useCalendarData =(transactions : ITransaction[])=>{
+const groupedTransaction = useMemo(() => {
+    const grouped: Record<string, DayData> = {};
+
+    transactions.forEach((transaction) => {
+      const dateKey = transaction.date;
+
+      if (!grouped[dateKey]) {
+        grouped[dateKey] = {
+          income: 0,
+          expense: 0,
+          transactions: [],
+        };
+      }
+
+      if (transaction.type === 'income') {
+        grouped[dateKey].income += transaction.amount;
+      } else if (transaction.type === 'expense') {
+        grouped[dateKey].expense += transaction.amount;
+      }
+
+      grouped[dateKey].transactions.push(transaction);
+    });
+
+    return grouped;
+  }, [transactions]);
+  const TransactionSummary = useMemo(() => {
+    const summary = transactions.reduce(
+      (acc, transaction) => {
+        if (transaction.type === 'income') {
+          acc.income += transaction.amount;
+        } else if (transaction.type === 'expense') {
+          acc.expense += transaction.amount;
+        }
+        return acc;
+      },
+      { income: 0, expense: 0 }
+    );
+
+    return summary;
+  }, [transactions]);
+
+  return{
+      groupedTransaction, TransactionSummary
+  }
+}

--- a/fe/src/hooks/useCalendarNavigation.ts
+++ b/fe/src/hooks/useCalendarNavigation.ts
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { formatMonth } from '@/utils/date';
+export const useCalendarNavigation = (
+  currentMonth: string,
+  onMonthChange: (month: string) => void
+) => {
+  const [month, setMonth] = useState<Date>(new Date(`${currentMonth}-01`));
+  const [date, setDate] = useState<Date | undefined>(new Date());
+
+  useEffect(() => {
+    setMonth(new Date(`${currentMonth}-01`));
+  }, [currentMonth]);
+
+  const handleMonthChange = (newMonth: Date) => {
+      setMonth(newMonth);
+      const monthString = formatMonth(newMonth);
+      onMonthChange(monthString);
+ };
+
+  const moveMonth = (offset: number) => {
+    const newDate = new Date(month.getFullYear(), month.getMonth() + offset, 1);
+    handleMonthChange(newDate);
+  };
+
+  const year = month.getFullYear();
+  const displayMonth = month.getMonth() + 1;
+
+  return {
+    month,
+    date,
+    setDate,
+    year,
+    displayMonth,
+    handleMonthChange,
+    moveMonth,
+  };
+};

--- a/fe/src/hooks/useCalendarNavigation.ts
+++ b/fe/src/hooks/useCalendarNavigation.ts
@@ -5,7 +5,9 @@ export const useCalendarNavigation = (
   currentMonth: string,
   onMonthChange: (month: string) => void
 ) => {
-  const [month, setMonth] = useState<Date>(new Date(`${currentMonth}-01`));
+  const [month, setMonth] = useState<Date>(
+    () => new Date(`${currentMonth}-01`)
+  );
   const [date, setDate] = useState<Date | undefined>(new Date());
 
   useEffect(() => {
@@ -13,13 +15,18 @@ export const useCalendarNavigation = (
   }, [currentMonth]);
 
   const handleMonthChange = (newMonth: Date) => {
-      setMonth(newMonth);
-      const monthString = formatMonth(newMonth);
-      onMonthChange(monthString);
- };
+    setMonth(newMonth);
+    const monthString = formatMonth(newMonth);
+    onMonthChange(monthString);
+  };
 
   const moveMonth = (offset: number) => {
     const newDate = new Date(month.getFullYear(), month.getMonth() + offset, 1);
+    handleMonthChange(newDate);
+  };
+
+  const navigateMonth = (target: number) => {
+    const newDate = new Date(month.getFullYear(), target - 1, 1);
     handleMonthChange(newDate);
   };
 
@@ -34,5 +41,6 @@ export const useCalendarNavigation = (
     displayMonth,
     handleMonthChange,
     moveMonth,
+    navigateMonth,
   };
 };

--- a/fe/src/hooks/useMonthTransactions.ts
+++ b/fe/src/hooks/useMonthTransactions.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getMonthTransactions } from '@/app/(app)/history/actions';
+import { ITransaction } from '@/types/transactions';
+
+interface MonthTransactionsProps {
+  month: string;
+  currentMonth: string;
+  initialTransactions?: ITransaction[];
+}
+
+export function useMonthTransactions({
+  month,
+  currentMonth,
+  initialTransactions,
+}: MonthTransactionsProps) {
+  return useQuery({
+    queryKey: ['transactions', month],
+    queryFn: () => getMonthTransactions(month),
+    initialData: month === currentMonth ? initialTransactions : undefined,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 30 * 60 * 1000,   // 30 minutes
+  });
+}


### PR DESCRIPTION
## PR 개요
- Calendar 데이터 페칭 방식 변경
- Calendar 기능 추가
- Calendar 컴포넌트 리팩토링 및 UI개선

## 변경 사항
1. 데이터 페칭 방식 변경
- 초기 진입 시 Server Action으로 현재 월 데이터를 SSR로 제공해 initialData로 설정
- 월 이동 시 Tanstack Query가 클라이언트에서 해당 월 데이터를 fetch
- 이미 조회한 월에 대해서 캐싱하여 데이터 즉시 반환
```
Supabase가 cookie기반이어서 next cache와 충돌해 동작하지 않는 이슈가 있었습니다.
따라서 당월 데이터는 Server Action으로 두고 당월 외 데이터는 tanstack query로
client caching을 해서 월 이동시 전체 리렌더링 없이 영역만 업데이트 하도록 했습니다.
```

2. 기능 추가
- 년-월 선택 이동 기능
- Loading spinner 추가

3. 리팩토링
- Calendar.tsx를 여러 컴포넌트로 분리
```
CalendarCaption.tsx - 캡션 영역
CalendarClient.tsx - 클라이언트 래퍼
CalendarDay.tsx - 일자 컴포넌트
```
- Regbar와 Month Navigation 배치 변경

## 리뷰 요청 사항
- 기존 캘린더 기능이 정상 작동 하는지
- 다른 월로 최초 이동시 loading 상태가 제대로 표시되는지
- 한번 조회했던 월로 다시 이동시 데이터가 바로 적용되는지

## 추후 할 일
- [ ] 가계부 + 캘린더페이지 통합