### PR TITLE
[fix] 모바일 키패드 노출 시 DrawerBottom 여백 발생 문제

### DIFF
--- a/fe/src/components/budgets/BudgetView.tsx
+++ b/fe/src/components/budgets/BudgetView.tsx
@@ -177,7 +177,6 @@ const BudgetView = ({
           setIsCategoryPanelOpen(open);
           if (!open) setActiveCategoryKey(null);
         }}
-        isFull
       >
         <BudgetCategorySetting
           selectedDate={selectedDate}

--- a/fe/src/components/panel/DrawerBottom.tsx
+++ b/fe/src/components/panel/DrawerBottom.tsx
@@ -13,7 +13,7 @@ import { X } from 'lucide-react';
 const DrawerBottom = ({ children, open, onOpenChange }: PanelProps) => {
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="flex h-dvh max-h-dvh flex-col overflow-hidden outline-none">
+      <DrawerContent className="fixed inset-0 flex h-full flex-col overflow-hidden rounded-none border-none outline-none">
         {/* DialogTitle 누락 방지 */}
         <DrawerTitle className="sr-only">DrawerBottom</DrawerTitle>
         <DrawerDescription className="sr-only">DrawerBottom</DrawerDescription>

--- a/fe/src/components/panel/DrawerBottom.tsx
+++ b/fe/src/components/panel/DrawerBottom.tsx
@@ -9,22 +9,11 @@ import {
 import { Button } from '@/components/ui/button';
 import { PanelProps } from '@/types/panel';
 import { X } from 'lucide-react';
-import { cn } from '@/lib/utils';
 
-const DrawerBottom = ({
-  children,
-  open,
-  onOpenChange,
-  isFull = false,
-}: PanelProps) => {
+const DrawerBottom = ({ children, open, onOpenChange }: PanelProps) => {
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent
-        className={cn(
-          'flex flex-col overflow-hidden outline-none',
-          isFull ? 'h-screen' : 'h-[80vh]'
-        )}
-      >
+      <DrawerContent className="flex h-dvh max-h-dvh flex-col overflow-hidden outline-none">
         {/* DialogTitle 누락 방지 */}
         <DrawerTitle className="sr-only">DrawerBottom</DrawerTitle>
         <DrawerDescription className="sr-only">DrawerBottom</DrawerDescription>

--- a/fe/src/components/panel/DrawerBottom.tsx
+++ b/fe/src/components/panel/DrawerBottom.tsx
@@ -11,9 +11,26 @@ import { PanelProps } from '@/types/panel';
 import { X } from 'lucide-react';
 
 const DrawerBottom = ({ children, open, onOpenChange }: PanelProps) => {
+  // 모바일 키보드 노출 시 input focus 스크롤 보정
+  const handleAutoScroll = (e: React.FocusEvent) => {
+    const target = e.target as HTMLElement;
+
+    if (target.tagName === 'INPUT') {
+      setTimeout(() => {
+        target.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      }, 200); // 키보드가 올라오는 시간 고려
+    }
+  };
+
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="fixed inset-0 flex h-full flex-col overflow-hidden rounded-none border-none outline-none">
+    <Drawer open={open} onOpenChange={onOpenChange} repositionInputs={false}>
+      <DrawerContent
+        className="fixed inset-0 flex h-full flex-col overflow-hidden rounded-none border-none outline-none"
+        onFocus={handleAutoScroll}
+      >
         {/* DialogTitle 누락 방지 */}
         <DrawerTitle className="sr-only">DrawerBottom</DrawerTitle>
         <DrawerDescription className="sr-only">DrawerBottom</DrawerDescription>

--- a/fe/src/components/panel/ResponsivePanel.tsx
+++ b/fe/src/components/panel/ResponsivePanel.tsx
@@ -15,7 +15,6 @@ interface ExternalResponsivePanelProps extends ResponsivePanelProps {
 const ResponsivePanel = ({
   trigger,
   children,
-  isFull = false,
   isOpen: externalIsOpen,
   setIsOpen: externalSetIsOpen,
 }: ExternalResponsivePanelProps) => {
@@ -41,11 +40,7 @@ const ResponsivePanel = ({
 
       <ResponsiveWrapper
         mobile={
-          <DrawerBottom
-            open={isPanelOpen}
-            onOpenChange={setIsPanelOpen}
-            isFull={isFull}
-          >
+          <DrawerBottom open={isPanelOpen} onOpenChange={setIsPanelOpen}>
             {children}
           </DrawerBottom>
         }

--- a/fe/src/components/ui/drawer.tsx
+++ b/fe/src/components/ui/drawer.tsx
@@ -56,9 +56,9 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'group/drawer-content bg-background fixed z-50 flex h-dvh flex-col',
           'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
-          'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-screen data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
+          'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-dvh data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
           'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
           'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm',
           className

--- a/fe/src/types/panel.ts
+++ b/fe/src/types/panel.ts
@@ -5,11 +5,9 @@ export interface PanelProps {
   children: React.ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  isFull?: boolean;
 }
 
 export interface ResponsivePanelProps {
   trigger?: React.ReactNode; // 패널을 열 버튼 등 트리거
   children: React.ReactNode; // 패널 내부에 들어갈 내용
-  isFull?: boolean;
 }


### PR DESCRIPTION
## PR 개요
- 모바일 환경에서 `Drawer` 내부 `input`에 포커스할 경우,
  키보드 노출로 인해 `Drawer` 하단에 의도하지 않은 여백이 생기거나
  UI가 잘리거나 `input`이 가려지는 문제를 해결했습니다.

## 변경 사항
### 1. Drawer 높이 계산 방식 개선 (dvh 적용)
- DrawerContent 높이를 `h-dvh / max-h-dvh` 기반으로 변경
- `isFull` 옵션 제거 후, 높이 계산 로직 단순화 → 전체 화면으로 통일

### 2. Drawer 위치 고정으로 키보드 노출 시 UI 안정화
- `DrawerBottom`의 `DrawerContent`를 `fixed` + `inset-0` 구조로 변경
- 키보드 노출 시 `Drawer` 전체가 밀리거나 잘리는 현상 수정

### 3. input 포커스 시 스크롤 보정 로직 추가
- `repositionInputs={false}` 설정으로 자동 레이아웃 보정 비활성화
- input `focus` 시 `scrollIntoView`를 사용해 포커스된 필드가 키보드 위로 노출되도록 보정

## 스크린샷 (선택)
### 가계부 패널
| Before | After |
|------------|------------|
| ![HomeDrawer_before](https://github.com/user-attachments/assets/7e4ceb2f-4f4a-4866-a4de-c3fbe6c94639) | ![HomeDrawer_after](https://github.com/user-attachments/assets/64a03206-4f13-4107-bbed-c9a7b8e342f8) |

### 카테고리 패널
| Before | After |
|------------|------------|
| ![BudgetDrawer_before](https://github.com/user-attachments/assets/56ea8fb9-27b9-48ac-b756-4270c4209058) | ![BudgetDrawer_after](https://github.com/user-attachments/assets/f8cef154-4cbf-4569-beed-b24a2db8cbc3) |

## 리뷰 요청 사항
- 저는 아래 방식으로 **실제 모바일 환경 테스트**를 진행했습니다.
- 접속 시, 게스트 모드로 확인해야

**모바일 테스트 방법**
1. 로컬 개발 서버 실행
2. VS Code 하단 **Ports** 탭에서 `3000` 포트 Forward
3. 생성된 주소로 모바일 브라우저에서 접속하여 확인  
   (기본 설정은 *Private* 이므로 GitHub 로그인이 필요할 수 있습니다)

<img width="1228" height="163" alt="image" src="https://github.com/user-attachments/assets/f0e9d621-34b0-493b-ae63-6e112911a0fe" />
  
- 관련 문서
  - 🔗 https://code.visualstudio.com/docs/debugtest/port-forwarding
  - 🔗 https://devtuts.net/en/vscode/port-forwarding.html


- ⚠️ **로그인 화면에서 소셜 로그인을 하면 배포된 Vercel URL로 리다이렉트되므로,
     반드시 게스트 모드에서 테스트 부탁드립니다.**
- 제 환경에서는 화면 잘림이나 여백 문제는 재현되지 않았으나,
  기기별 차이가 있을 수 있어 가능하다면 직접 확인 부탁드립니다 🙏

## 추후 할 일

- [ ] 분석 페이지 차트 개선