### PR TITLE
[feat] 고정비 규칙 필터링 및 검색 기능 추가

### DIFF
--- a/fe/src/app/(app)/fixed-costs/FixedCostsContext.tsx
+++ b/fe/src/app/(app)/fixed-costs/FixedCostsContext.tsx
@@ -9,6 +9,8 @@ interface FixedCostsContextType {
   openCreate: () => void;
   openEdit: (rule: IFixedRule) => void;
   close: () => void;
+  isFiltering: boolean;
+  setIsFiltering: (v: boolean) => void;
 }
 
 const FixedCostsContext = createContext<FixedCostsContextType | undefined>(
@@ -18,6 +20,7 @@ const FixedCostsContext = createContext<FixedCostsContextType | undefined>(
 export function FixedCostsProvider({ children }: { children: ReactNode }) {
   const [selectedRule, setSelectedRule] = useState<IFixedRule | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [isFiltering, setIsFiltering] = useState(false);
 
   const openCreate = () => {
     setSelectedRule(null);
@@ -33,7 +36,15 @@ export function FixedCostsProvider({ children }: { children: ReactNode }) {
 
   return (
     <FixedCostsContext.Provider
-      value={{ selectedRule, isOpen, openCreate, openEdit, close }}
+      value={{
+        selectedRule,
+        isOpen,
+        openCreate,
+        openEdit,
+        close,
+        isFiltering,
+        setIsFiltering,
+      }}
     >
       {children}
     </FixedCostsContext.Provider>

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -14,6 +14,7 @@ interface PageProps {
     cycle?: string;
     start_date?: string;
     end_date?: string;
+    query?: string;
   }>;
 }
 
@@ -34,6 +35,7 @@ export default async function FixedCostsPage({ searchParams }: PageProps) {
         : undefined,
     start_date: startDate ? formatLocalDate(startDate) : undefined,
     end_date: endDate ? formatLocalDate(endDate) : undefined,
+    query: params.query?.trim() ? params.query.trim() : undefined,
   };
 
   return (

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -10,6 +10,7 @@ import type { FixedCostsFilters as Filters } from '@/types/fixed-costs';
 interface PageProps {
   searchParams: Promise<{
     type?: string;
+    cycle?: string;
   }>;
 }
 
@@ -20,6 +21,10 @@ export default async function FixedCostsPage({ searchParams }: PageProps) {
     type:
       params.type === 'income' || params.type === 'expense'
         ? params.type
+        : undefined,
+    cycle:
+      params.cycle === 'WEEKLY' || params.cycle === 'MONTHLY'
+        ? params.cycle
         : undefined,
   };
 

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -6,16 +6,22 @@ import { Suspense } from 'react';
 import { FixedCostsProvider } from './FixedCostsContext';
 import FixedCostsFilters from '@/components/fixed-costs/FixedCostsFilters';
 import type { FixedCostsFilters as Filters } from '@/types/fixed-costs';
+import { formatLocalDate, parseLocalDate } from '@/utils/date';
 
 interface PageProps {
   searchParams: Promise<{
     type?: string;
     cycle?: string;
+    start_date?: string;
+    end_date?: string;
   }>;
 }
 
 export default async function FixedCostsPage({ searchParams }: PageProps) {
   const params = await searchParams;
+
+  const startDate = parseLocalDate(params.start_date);
+  const endDate = parseLocalDate(params.end_date);
 
   const filters: Filters = {
     type:
@@ -26,6 +32,8 @@ export default async function FixedCostsPage({ searchParams }: PageProps) {
       params.cycle === 'WEEKLY' || params.cycle === 'MONTHLY'
         ? params.cycle
         : undefined,
+    start_date: startDate ? formatLocalDate(startDate) : undefined,
+    end_date: endDate ? formatLocalDate(endDate) : undefined,
   };
 
   return (

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -4,6 +4,7 @@ import FixedCostsListSkeleton from '@/components/fixed-costs/FixedCostsListSkele
 import { fetchFixedRulesServer } from '@/services/fixed-costs/fixedCostsServer';
 import { Suspense } from 'react';
 import { FixedCostsProvider } from './FixedCostsContext';
+import FixedCostsFilters from '@/components/fixed-costs/FixedCostsFilters';
 
 export default function FixedCostsPage() {
   return (
@@ -14,6 +15,7 @@ export default function FixedCostsPage() {
             <header>
               <h1 className="text-xl font-semibold">고정비 관리</h1>
             </header>
+            <FixedCostsFilters />
           </div>
         </div>
         <FixedCostsClient />

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -5,8 +5,24 @@ import { fetchFixedRulesServer } from '@/services/fixed-costs/fixedCostsServer';
 import { Suspense } from 'react';
 import { FixedCostsProvider } from './FixedCostsContext';
 import FixedCostsFilters from '@/components/fixed-costs/FixedCostsFilters';
+import type { FixedCostsFilters as Filters } from '@/types/fixed-costs';
 
-export default function FixedCostsPage() {
+interface PageProps {
+  searchParams: Promise<{
+    type?: string;
+  }>;
+}
+
+export default async function FixedCostsPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+
+  const filters: Filters = {
+    type:
+      params.type === 'income' || params.type === 'expense'
+        ? params.type
+        : undefined,
+  };
+
   return (
     <FixedCostsProvider>
       <div className="flex min-h-screen w-full flex-col">
@@ -21,15 +37,15 @@ export default function FixedCostsPage() {
         <FixedCostsClient />
 
         <Suspense fallback={<FixedCostsListSkeleton />}>
-          <FixedCostsListWrapper />
+          <FixedCostsListWrapper filters={filters} />
         </Suspense>
       </div>
     </FixedCostsProvider>
   );
 }
 
-async function FixedCostsListWrapper() {
-  const items = await fetchFixedRulesServer();
+async function FixedCostsListWrapper({ filters }: { filters: Filters }) {
+  const items = await fetchFixedRulesServer(filters);
 
   return <FixedCostsList items={items} />;
 }

--- a/fe/src/components/fixed-costs/FixedCostItem.tsx
+++ b/fe/src/components/fixed-costs/FixedCostItem.tsx
@@ -15,6 +15,12 @@ type FixedCostItemProps = {
   onEdit?: (rule: IFixedRule) => void;
 };
 
+function formatRuleRange(rule: IFixedRule) {
+  const start = rule.start_date;
+  const end = rule.end_date ?? '';
+  return end ? `${start} ~ ${end}` : `${start} ~`;
+}
+
 export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
   const isEnded = isEndedFixedRule(rule);
 
@@ -30,48 +36,56 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
     <Item
       variant="outline"
       className={cn(
-        'hover:border-brand-soft cursor-pointer transition-colors',
-        isEnded ? 'opacity-60' : ''
+        'hover:border-brand-soft relative cursor-pointer transition-colors',
+        isEnded && 'opacity-60'
       )}
       onClick={handleClick}
     >
-      <ItemContent className="flex flex-row items-center">
-        {/* 좌측: 주기 + 금액 */}
-        <div className="flex w-32 flex-col gap-1">
-          <span className="text-muted-foreground text-xs">
-            {formatFixedRuleCycle(rule)}
-          </span>
-          <span
-            className={cn(
-              'text-sm font-bold',
-              rule.type === 'income' ? THEME_COLOR.INCOME : THEME_COLOR.EXPENSE
-            )}
-          >
-            {rule.type === 'income' ? '+' : '-'}
-            {rule.amount.toLocaleString()}원
-          </span>
+      <ItemContent className="flex flex-col gap-2">
+        {/* 상단: 기간 / 상태 뱃지 */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary" className="h-5 px-2 text-xs">
+            {formatRuleRange(rule)}
+          </Badge>
+
+          {isEnded && (
+            <Badge variant="secondary" className="h-5 px-2 text-xs">
+              종료됨
+            </Badge>
+          )}
         </div>
 
-        {/* 중앙: 카테고리 + 제목 */}
-        <div className="pl-2">
-          <ItemTitle className="text-muted-foreground pl-2 text-left text-xs">
-            {categoryName}
-          </ItemTitle>
-          <ItemTitle className="p-2 text-left">
-            {rule.title}
-            {isEnded && (
-              <Badge variant="secondary" className="h-5 px-2 text-xs">
-                종료됨
-              </Badge>
-            )}
-          </ItemTitle>
-        </div>
+        {/* 본문 */}
+        <div className="flex flex-row items-center">
+          <div className="flex w-32 flex-col gap-1">
+            <span className="text-muted-foreground text-xs">
+              {formatFixedRuleCycle(rule)}
+            </span>
+            <span
+              className={cn(
+                'text-sm font-bold',
+                rule.type === 'income'
+                  ? THEME_COLOR.INCOME
+                  : THEME_COLOR.EXPENSE
+              )}
+            >
+              {rule.type === 'income' ? '+' : '-'}
+              {rule.amount.toLocaleString()}원
+            </span>
+          </div>
 
-        {/* 우측 */}
-        <div className="ml-auto">
-          <ChevronRight />
+          <div className="min-w-0 flex-1 pl-2">
+            <ItemTitle className="text-muted-foreground text-xs">
+              {categoryName}
+            </ItemTitle>
+            <ItemTitle className="line-clamp-2 text-sm font-medium">
+              {rule.title}
+            </ItemTitle>
+          </div>
         </div>
       </ItemContent>
+
+      <ChevronRight className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2" />
     </Item>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostItem.tsx
+++ b/fe/src/components/fixed-costs/FixedCostItem.tsx
@@ -56,7 +56,7 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
         </div>
 
         {/* 본문 */}
-        <div className="flex flex-row items-center">
+        <div className="flex flex-row items-center pr-5">
           <div className="flex w-32 flex-col gap-1">
             <span className="text-muted-foreground text-xs">
               {formatFixedRuleCycle(rule)}
@@ -85,7 +85,7 @@ export default function FixedCostItem({ rule, onEdit }: FixedCostItemProps) {
         </div>
       </ItemContent>
 
-      <ChevronRight className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2" />
+      <ChevronRight className="absolute top-1/2 right-3 -translate-y-1/2" />
     </Item>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as React from 'react';
 import {
   Select,
   SelectContent,
@@ -8,14 +9,23 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useFixedCostsFilters } from '@/hooks/useFixedCostsFilters';
+import { formatLocalDate, parseLocalDate } from '@/utils/date';
+import RangeDatePicker from './RangeDatePicker';
 
 export default function FixedCostsFilters() {
-  const { searchParams, updateFilter } = useFixedCostsFilters();
+  const { searchParams, updateFilter, updateFilters } = useFixedCostsFilters();
   const type = searchParams.get('type') || 'all';
   const cycle = searchParams.get('cycle') || 'all';
+  const start = parseLocalDate(searchParams.get('start_date'));
+  const end = parseLocalDate(searchParams.get('end_date'));
+
+  const [endEnabled, setEndEnabled] = React.useState<boolean>(!!end);
+  React.useEffect(() => {
+    if (!end) setEndEnabled(false);
+  }, [end]);
 
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-center gap-2">
       {/* 타입 */}
       <Select
         value={type}
@@ -29,22 +39,62 @@ export default function FixedCostsFilters() {
           <SelectItem value="income">수입</SelectItem>
           <SelectItem value="expense">지출</SelectItem>
         </SelectContent>
-
-        {/* 반복 주기 */}
-        <Select
-          value={cycle}
-          onValueChange={(value) => updateFilter('cycle', value)}
-        >
-          <SelectTrigger className="w-32">
-            <SelectValue placeholder="주기" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">전체</SelectItem>
-            <SelectItem value="MONTHLY">월간</SelectItem>
-            <SelectItem value="WEEKLY">주간</SelectItem>
-          </SelectContent>
-        </Select>
       </Select>
+
+      {/* 반복 주기 */}
+      <Select
+        value={cycle}
+        onValueChange={(value) => updateFilter('cycle', value)}
+      >
+        <SelectTrigger className="w-32">
+          <SelectValue placeholder="주기" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">전체</SelectItem>
+          <SelectItem value="MONTHLY">월간</SelectItem>
+          <SelectItem value="WEEKLY">주간</SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* 기간 */}
+      <RangeDatePicker
+        start={start}
+        end={end}
+        endEnabled={endEnabled}
+        onChange={({ start, end, endEnabled }) => {
+          setEndEnabled(endEnabled);
+
+          // start가 없으면 전체 초기화
+          if (!start) {
+            updateFilters({ start_date: 'all', end_date: 'all' });
+            return;
+          }
+
+          const startStr = formatLocalDate(start);
+
+          // 토글 OFF면 end는 제거
+          if (!endEnabled) {
+            updateFilters({ start_date: startStr, end_date: 'all' });
+            return;
+          }
+
+          // 토글 ON인데 end가 아직 없으면: start만 유지하고 end는 비움
+          if (!end) {
+            updateFilters({ start_date: startStr, end_date: 'all' });
+            return;
+          }
+
+          const endStr = formatLocalDate(end);
+
+          // end < start면 swap
+          if (endStr < startStr) {
+            updateFilters({ start_date: endStr, end_date: startStr });
+            return;
+          }
+
+          updateFilters({ start_date: startStr, end_date: endStr });
+        }}
+      />
     </div>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -11,26 +11,84 @@ import {
 import { useFixedCostsFilters } from '@/hooks/useFixedCostsFilters';
 import { formatLocalDate, parseLocalDate } from '@/utils/date';
 import RangeDatePicker from './RangeDatePicker';
-import { cn } from '@/lib/utils';
 import { Input } from '../ui/input';
-import { Filter, RotateCcw } from 'lucide-react';
+import { Search, LayoutGrid, Repeat, RotateCcw, Check } from 'lucide-react';
 import { Button } from '../ui/button';
 
+type LocalFilters = {
+  type: string;
+  cycle: string;
+  start?: Date;
+  end?: Date;
+};
+
 export default function FixedCostsFilters() {
-  const { searchParams, updateFilter, updateFilters } = useFixedCostsFilters();
-  const type = searchParams.get('type') || 'all';
-  const cycle = searchParams.get('cycle') || 'all';
-  const start = parseLocalDate(searchParams.get('start_date'));
-  const end = parseLocalDate(searchParams.get('end_date'));
+  const { searchParams, updateFilters } = useFixedCostsFilters();
 
-  const [endEnabled, setEndEnabled] = React.useState<boolean>(!!end);
-  React.useEffect(() => {
-    if (!end) setEndEnabled(false);
-  }, [end]);
+  // 내부 로컬 상태로 관리
+  const [localFilters, setLocalFilters] = React.useState<LocalFilters>({
+    type: searchParams.get('type') || 'all',
+    cycle: searchParams.get('cycle') || 'all',
+    start: parseLocalDate(searchParams.get('start_date')),
+    end: parseLocalDate(searchParams.get('end_date')),
+  });
 
-  const resetFilters = () => {
+  const [endEnabled, setEndEnabled] = React.useState<boolean>(
+    !!localFilters.end
+  );
+
+  // 검색 실행 함수
+  const handleApply = () => {
+    const startStr = localFilters.start
+      ? formatLocalDate(localFilters.start)
+      : 'all';
+    const endStr =
+      endEnabled && localFilters.end
+        ? formatLocalDate(localFilters.end)
+        : 'all';
+
+    // start가 없으면 기간은 둘 다 해제
+    if (startStr === 'all') {
+      updateFilters({
+        type: localFilters.type,
+        cycle: localFilters.cycle,
+        start_date: 'all',
+        end_date: 'all',
+      });
+      return;
+    }
+
+    // end가 없으면 start만 유지
+    if (endStr === 'all') {
+      updateFilters({
+        type: localFilters.type,
+        cycle: localFilters.cycle,
+        start_date: startStr,
+        end_date: 'all',
+      });
+      return;
+    }
+
+    // 둘 다 있으면 swap 보정
+    const from = endStr < startStr ? endStr : startStr;
+    const to = endStr < startStr ? startStr : endStr;
+
+    updateFilters({
+      type: localFilters.type,
+      cycle: localFilters.cycle,
+      start_date: from,
+      end_date: to,
+    });
+  };
+
+  const handleReset = () => {
+    setLocalFilters({
+      type: 'all',
+      cycle: 'all',
+      start: undefined,
+      end: undefined,
+    });
     setEndEnabled(false);
-
     updateFilters({
       type: 'all',
       cycle: 'all',
@@ -40,113 +98,88 @@ export default function FixedCostsFilters() {
   };
 
   return (
-    <section className="w-full rounded-xl border p-3">
-      <div className="mb-3 flex items-center justify-between">
-        <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
-          <Filter className="h-4 w-4" />
-          필터
+    <section className="bg-brand-subtle/30 border-brand-soft/20 w-full rounded-lg border p-4 shadow-sm">
+      <div className="flex flex-col gap-4">
+        {/* 검색창 */}
+        <div className="group relative">
+          <Search className="text-brand-neutral group-focus-within:text-brand absolute top-1/2 left-3.5 h-4 w-4 -translate-y-1/2 transition-colors" />
+          <Input
+            placeholder="어떤 내역을 찾으시나요?"
+            className="ring-brand-neutral/20 focus-visible:ring-brand-soft placeholder:text-brand-neutral h-10 border-none bg-white pl-11 shadow-sm ring-1"
+          />
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-8"
-          onClick={resetFilters}
-        >
-          <RotateCcw className="mr-1 h-4 w-4" />
-          초기화
-        </Button>
-      </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        {/* 타입 */}
-        <Select
-          value={type}
-          onValueChange={(value) => updateFilter('type', value)}
-        >
-          <SelectTrigger
-            className={cn(
-              'min-w-[96px]',
-              type === 'all' && 'text-muted-foreground'
-            )}
+        {/* 필터 컨트롤 그룹 */}
+        <div className="flex flex-wrap items-center gap-3">
+          <Select
+            value={localFilters.type}
+            onValueChange={(v) =>
+              setLocalFilters((prev) => ({ ...prev, type: v }))
+            }
           >
-            <SelectValue>
-              {type === 'all' ? '타입' : type === 'income' ? '수입' : '지출'}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">전체</SelectItem>
-            <SelectItem value="income">수입</SelectItem>
-            <SelectItem value="expense">지출</SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectTrigger className="ring-brand-neutral/20 focus:ring-brand h-10 min-w-[120px] flex-1 border-none bg-white ring-1 md:w-[140px] md:flex-none">
+              <div className="flex items-center gap-2">
+                <LayoutGrid className="text-brand h-4 w-4 opacity-60" />
+                <SelectValue placeholder="타입" />
+              </div>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">전체 타입</SelectItem>
+              <SelectItem value="income">수입</SelectItem>
+              <SelectItem value="expense">지출</SelectItem>
+            </SelectContent>
+          </Select>
 
-        {/* 반복 주기 */}
-        <Select
-          value={cycle}
-          onValueChange={(value) => updateFilter('cycle', value)}
-        >
-          <SelectTrigger
-            className={cn(
-              'min-w-[96px]',
-              cycle === 'all' && 'text-muted-foreground'
-            )}
+          <Select
+            value={localFilters.cycle}
+            onValueChange={(v) =>
+              setLocalFilters((prev) => ({ ...prev, cycle: v }))
+            }
           >
-            <SelectValue>
-              {cycle === 'all' ? '주기' : cycle === 'MONTHLY' ? '월간' : '주간'}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">전체</SelectItem>
-            <SelectItem value="MONTHLY">월간</SelectItem>
-            <SelectItem value="WEEKLY">주간</SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectTrigger className="ring-brand-neutral/20 focus:ring-brand h-10 min-w-[120px] flex-1 border-none bg-white ring-1 md:w-[140px] md:flex-none">
+              <div className="flex items-center gap-2">
+                <Repeat className="text-brand h-4 w-4 opacity-60" />
+                <SelectValue placeholder="주기" />
+              </div>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">전체 주기</SelectItem>
+              <SelectItem value="MONTHLY">월간</SelectItem>
+              <SelectItem value="WEEKLY">주간</SelectItem>
+            </SelectContent>
+          </Select>
 
-        {/* 기간 */}
-        <RangeDatePicker
-          start={start}
-          end={end}
-          endEnabled={endEnabled}
-          onChange={({ start, end, endEnabled }) => {
-            setEndEnabled(endEnabled);
+          <RangeDatePicker
+            start={localFilters.start}
+            end={localFilters.end}
+            endEnabled={endEnabled}
+            onChange={({ start, end, endEnabled }) => {
+              setEndEnabled(endEnabled);
+              setLocalFilters((prev) => ({ ...prev, start, end }));
+            }}
+          />
+        </div>
 
-            // start가 없으면 전체 초기화
-            if (!start) {
-              updateFilters({ start_date: 'all', end_date: 'all' });
-              return;
-            }
-
-            const startStr = formatLocalDate(start);
-
-            // 토글 OFF면 end는 제거
-            if (!endEnabled) {
-              updateFilters({ start_date: startStr, end_date: 'all' });
-              return;
-            }
-
-            // 토글 ON인데 end가 아직 없으면: start만 유지하고 end는 비움
-            if (!end) {
-              updateFilters({ start_date: startStr, end_date: 'all' });
-              return;
-            }
-
-            const endStr = formatLocalDate(end);
-
-            // end < start면 swap
-            if (endStr < startStr) {
-              updateFilters({ start_date: endStr, end_date: startStr });
-              return;
-            }
-
-            updateFilters({ start_date: startStr, end_date: endStr });
-          }}
-        />
-      </div>
-
-      {/* 검색 */}
-      <div className="mt-2 min-w-[180px] flex-1">
-        <Input placeholder="검색..." className="h-9" />
+        {/* 액션 버튼 그룹 */}
+        <div className="border-brand-soft/10 flex items-center justify-end gap-2 border-t pt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-soft/20 h-9 px-4"
+          >
+            <RotateCcw className="mr-1 h-3.5 w-3.5" />
+            초기화
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleApply}
+            className="bg-brand hover:bg-brand-strong h-9 rounded-lg px-6 text-white shadow-md transition-all active:scale-95"
+          >
+            <Check className="mr-1.5 h-4 w-4" />
+            조건 적용하기
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -12,9 +12,11 @@ import { useFixedCostsFilters } from '@/hooks/useFixedCostsFilters';
 export default function FixedCostsFilters() {
   const { searchParams, updateFilter } = useFixedCostsFilters();
   const type = searchParams.get('type') || 'all';
+  const cycle = searchParams.get('cycle') || 'all';
 
   return (
     <div className="flex items-center justify-between">
+      {/* 타입 */}
       <Select
         value={type}
         onValueChange={(value) => updateFilter('type', value)}
@@ -27,6 +29,21 @@ export default function FixedCostsFilters() {
           <SelectItem value="income">수입</SelectItem>
           <SelectItem value="expense">지출</SelectItem>
         </SelectContent>
+
+        {/* 반복 주기 */}
+        <Select
+          value={cycle}
+          onValueChange={(value) => updateFilter('cycle', value)}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="주기" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체</SelectItem>
+            <SelectItem value="MONTHLY">월간</SelectItem>
+            <SelectItem value="WEEKLY">주간</SelectItem>
+          </SelectContent>
+        </Select>
       </Select>
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -121,7 +121,7 @@ export default function FixedCostsFilters() {
   };
 
   return (
-    <section className="bg-brand-subtle/30 border-brand-soft/20 w-full rounded-lg border p-4 shadow-sm">
+    <section className="bg-brand-subtle/30 border-brand-soft/20 w-full rounded-lg border p-4 shadow-sm dark:bg-neutral-900 dark:text-neutral-100">
       <div className="flex flex-col gap-4">
         {/* 검색창 */}
         <div className="group relative">
@@ -196,7 +196,7 @@ export default function FixedCostsFilters() {
             variant="ghost"
             size="sm"
             onClick={handleReset}
-            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-soft/20 h-9 px-4"
+            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-soft/20 h-9 px-4 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
           >
             <RotateCcw className="mr-1 h-3.5 w-3.5" />
             초기화

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useFixedCostsFilters } from '@/hooks/useFixedCostsFilters';
+
+export default function FixedCostsFilters() {
+  const { searchParams, updateFilter } = useFixedCostsFilters();
+  const type = searchParams.get('type') || 'all';
+
+  return (
+    <div className="flex items-center justify-between">
+      <Select
+        value={type}
+        onValueChange={(value) => updateFilter('type', value)}
+      >
+        <SelectTrigger className="w-32">
+          <SelectValue placeholder="타입" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">전체</SelectItem>
+          <SelectItem value="income">수입</SelectItem>
+          <SelectItem value="expense">지출</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -20,6 +20,7 @@ type LocalFilters = {
   cycle: string;
   start?: Date;
   end?: Date;
+  query: string;
 };
 
 export default function FixedCostsFilters() {
@@ -31,6 +32,7 @@ export default function FixedCostsFilters() {
     cycle: searchParams.get('cycle') || 'all',
     start: parseLocalDate(searchParams.get('start_date')),
     end: parseLocalDate(searchParams.get('end_date')),
+    query: searchParams.get('query') ?? '',
   });
 
   const [endEnabled, setEndEnabled] = React.useState<boolean>(
@@ -47,6 +49,7 @@ export default function FixedCostsFilters() {
       cycle: searchParams.get('cycle') || 'all',
       start: nextStart,
       end: nextEnd,
+      query: searchParams.get('query') ?? '',
     });
 
     // URL에 end_date가 있으면 토글 ON, 없으면 OFF
@@ -70,6 +73,7 @@ export default function FixedCostsFilters() {
         cycle: localFilters.cycle,
         start_date: 'all',
         end_date: 'all',
+        query: localFilters.query || 'all',
       });
       return;
     }
@@ -80,7 +84,7 @@ export default function FixedCostsFilters() {
         type: localFilters.type,
         cycle: localFilters.cycle,
         start_date: startStr,
-        end_date: 'all',
+        query: localFilters.query || 'all',
       });
       return;
     }
@@ -94,6 +98,7 @@ export default function FixedCostsFilters() {
       cycle: localFilters.cycle,
       start_date: from,
       end_date: to,
+      query: localFilters.query || 'all',
     });
   };
 
@@ -103,6 +108,7 @@ export default function FixedCostsFilters() {
       cycle: 'all',
       start: undefined,
       end: undefined,
+      query: '',
     });
     setEndEnabled(false);
     updateFilters({
@@ -110,6 +116,7 @@ export default function FixedCostsFilters() {
       cycle: 'all',
       start_date: 'all',
       end_date: 'all',
+      query: 'all',
     });
   };
 
@@ -120,6 +127,13 @@ export default function FixedCostsFilters() {
         <div className="group relative">
           <Search className="text-brand-neutral group-focus-within:text-brand absolute top-1/2 left-3.5 h-4 w-4 -translate-y-1/2 transition-colors" />
           <Input
+            value={localFilters.query}
+            onChange={(e) =>
+              setLocalFilters((prev) => ({
+                ...prev,
+                query: e.target.value,
+              }))
+            }
             placeholder="어떤 내역을 찾으시나요?"
             className="ring-brand-neutral/20 focus-visible:ring-brand-soft placeholder:text-brand-neutral h-10 border-none bg-white pl-11 shadow-sm ring-1"
           />

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -25,7 +25,7 @@ type LocalFilters = {
 export default function FixedCostsFilters() {
   const { searchParams, updateFilters } = useFixedCostsFilters();
 
-  // 내부 로컬 상태로 관리
+  // 로컬 상태로 필터 초기값 설정
   const [localFilters, setLocalFilters] = React.useState<LocalFilters>({
     type: searchParams.get('type') || 'all',
     cycle: searchParams.get('cycle') || 'all',
@@ -36,6 +36,22 @@ export default function FixedCostsFilters() {
   const [endEnabled, setEndEnabled] = React.useState<boolean>(
     !!localFilters.end
   );
+
+  // URL(searchParams)이 바뀌면 로컬 상태도 동기화
+  React.useEffect(() => {
+    const nextStart = parseLocalDate(searchParams.get('start_date'));
+    const nextEnd = parseLocalDate(searchParams.get('end_date'));
+
+    setLocalFilters({
+      type: searchParams.get('type') || 'all',
+      cycle: searchParams.get('cycle') || 'all',
+      start: nextStart,
+      end: nextEnd,
+    });
+
+    // URL에 end_date가 있으면 토글 ON, 없으면 OFF
+    setEndEnabled(!!nextEnd);
+  }, [searchParams.toString()]);
 
   // 검색 실행 함수
   const handleApply = () => {

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import {
   Select,
   SelectContent,
@@ -14,6 +14,7 @@ import RangeDatePicker from './RangeDatePicker';
 import { Input } from '../ui/input';
 import { Search, LayoutGrid, Repeat, RotateCcw, Check } from 'lucide-react';
 import { Button } from '../ui/button';
+import { useFixedCosts } from '@/app/(app)/fixed-costs/FixedCostsContext';
 
 type LocalFilters = {
   type: string;
@@ -26,8 +27,16 @@ type LocalFilters = {
 export default function FixedCostsFilters() {
   const { searchParams, updateFilters } = useFixedCostsFilters();
 
+  const [isPending, startTransition] = useTransition();
+  const { setIsFiltering } = useFixedCosts();
+
+  // transition 상태를 Context에 반영
+  useEffect(() => {
+    setIsFiltering(isPending);
+  }, [isPending, setIsFiltering]);
+
   // 로컬 상태로 필터 초기값 설정
-  const [localFilters, setLocalFilters] = React.useState<LocalFilters>({
+  const [localFilters, setLocalFilters] = useState<LocalFilters>({
     type: searchParams.get('type') || 'all',
     cycle: searchParams.get('cycle') || 'all',
     start: parseLocalDate(searchParams.get('start_date')),
@@ -35,12 +44,10 @@ export default function FixedCostsFilters() {
     query: searchParams.get('query') ?? '',
   });
 
-  const [endEnabled, setEndEnabled] = React.useState<boolean>(
-    !!localFilters.end
-  );
+  const [endEnabled, setEndEnabled] = useState<boolean>(!!localFilters.end);
 
   // URL(searchParams)이 바뀌면 로컬 상태도 동기화
-  React.useEffect(() => {
+  useEffect(() => {
     const nextStart = parseLocalDate(searchParams.get('start_date'));
     const nextEnd = parseLocalDate(searchParams.get('end_date'));
 
@@ -203,11 +210,16 @@ export default function FixedCostsFilters() {
           </Button>
           <Button
             size="sm"
-            onClick={handleApply}
+            onClick={() =>
+              startTransition(() => {
+                handleApply();
+              })
+            }
+            disabled={isPending}
             className="bg-brand hover:bg-brand-strong h-9 rounded-lg px-6 text-white shadow-md transition-all active:scale-95"
           >
             <Check className="mr-1.5 h-4 w-4" />
-            조건 적용하기
+            {isPending ? '적용 중…' : '조건 적용하기'}
           </Button>
         </div>
       </div>

--- a/fe/src/components/fixed-costs/FixedCostsFilters.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsFilters.tsx
@@ -11,6 +11,10 @@ import {
 import { useFixedCostsFilters } from '@/hooks/useFixedCostsFilters';
 import { formatLocalDate, parseLocalDate } from '@/utils/date';
 import RangeDatePicker from './RangeDatePicker';
+import { cn } from '@/lib/utils';
+import { Input } from '../ui/input';
+import { Filter, RotateCcw } from 'lucide-react';
+import { Button } from '../ui/button';
 
 export default function FixedCostsFilters() {
   const { searchParams, updateFilter, updateFilters } = useFixedCostsFilters();
@@ -24,77 +28,126 @@ export default function FixedCostsFilters() {
     if (!end) setEndEnabled(false);
   }, [end]);
 
+  const resetFilters = () => {
+    setEndEnabled(false);
+
+    updateFilters({
+      type: 'all',
+      cycle: 'all',
+      start_date: 'all',
+      end_date: 'all',
+    });
+  };
+
   return (
-    <div className="flex items-center gap-2">
-      {/* 타입 */}
-      <Select
-        value={type}
-        onValueChange={(value) => updateFilter('type', value)}
-      >
-        <SelectTrigger className="w-32">
-          <SelectValue placeholder="타입" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">전체</SelectItem>
-          <SelectItem value="income">수입</SelectItem>
-          <SelectItem value="expense">지출</SelectItem>
-        </SelectContent>
-      </Select>
+    <section className="w-full rounded-xl border p-3">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="text-muted-foreground flex items-center gap-2 text-sm font-medium">
+          <Filter className="h-4 w-4" />
+          필터
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8"
+          onClick={resetFilters}
+        >
+          <RotateCcw className="mr-1 h-4 w-4" />
+          초기화
+        </Button>
+      </div>
 
-      {/* 반복 주기 */}
-      <Select
-        value={cycle}
-        onValueChange={(value) => updateFilter('cycle', value)}
-      >
-        <SelectTrigger className="w-32">
-          <SelectValue placeholder="주기" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">전체</SelectItem>
-          <SelectItem value="MONTHLY">월간</SelectItem>
-          <SelectItem value="WEEKLY">주간</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex flex-wrap items-center gap-2">
+        {/* 타입 */}
+        <Select
+          value={type}
+          onValueChange={(value) => updateFilter('type', value)}
+        >
+          <SelectTrigger
+            className={cn(
+              'min-w-[96px]',
+              type === 'all' && 'text-muted-foreground'
+            )}
+          >
+            <SelectValue>
+              {type === 'all' ? '타입' : type === 'income' ? '수입' : '지출'}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체</SelectItem>
+            <SelectItem value="income">수입</SelectItem>
+            <SelectItem value="expense">지출</SelectItem>
+          </SelectContent>
+        </Select>
 
-      {/* 기간 */}
-      <RangeDatePicker
-        start={start}
-        end={end}
-        endEnabled={endEnabled}
-        onChange={({ start, end, endEnabled }) => {
-          setEndEnabled(endEnabled);
+        {/* 반복 주기 */}
+        <Select
+          value={cycle}
+          onValueChange={(value) => updateFilter('cycle', value)}
+        >
+          <SelectTrigger
+            className={cn(
+              'min-w-[96px]',
+              cycle === 'all' && 'text-muted-foreground'
+            )}
+          >
+            <SelectValue>
+              {cycle === 'all' ? '주기' : cycle === 'MONTHLY' ? '월간' : '주간'}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체</SelectItem>
+            <SelectItem value="MONTHLY">월간</SelectItem>
+            <SelectItem value="WEEKLY">주간</SelectItem>
+          </SelectContent>
+        </Select>
 
-          // start가 없으면 전체 초기화
-          if (!start) {
-            updateFilters({ start_date: 'all', end_date: 'all' });
-            return;
-          }
+        {/* 기간 */}
+        <RangeDatePicker
+          start={start}
+          end={end}
+          endEnabled={endEnabled}
+          onChange={({ start, end, endEnabled }) => {
+            setEndEnabled(endEnabled);
 
-          const startStr = formatLocalDate(start);
+            // start가 없으면 전체 초기화
+            if (!start) {
+              updateFilters({ start_date: 'all', end_date: 'all' });
+              return;
+            }
 
-          // 토글 OFF면 end는 제거
-          if (!endEnabled) {
-            updateFilters({ start_date: startStr, end_date: 'all' });
-            return;
-          }
+            const startStr = formatLocalDate(start);
 
-          // 토글 ON인데 end가 아직 없으면: start만 유지하고 end는 비움
-          if (!end) {
-            updateFilters({ start_date: startStr, end_date: 'all' });
-            return;
-          }
+            // 토글 OFF면 end는 제거
+            if (!endEnabled) {
+              updateFilters({ start_date: startStr, end_date: 'all' });
+              return;
+            }
 
-          const endStr = formatLocalDate(end);
+            // 토글 ON인데 end가 아직 없으면: start만 유지하고 end는 비움
+            if (!end) {
+              updateFilters({ start_date: startStr, end_date: 'all' });
+              return;
+            }
 
-          // end < start면 swap
-          if (endStr < startStr) {
-            updateFilters({ start_date: endStr, end_date: startStr });
-            return;
-          }
+            const endStr = formatLocalDate(end);
 
-          updateFilters({ start_date: startStr, end_date: endStr });
-        }}
-      />
-    </div>
+            // end < start면 swap
+            if (endStr < startStr) {
+              updateFilters({ start_date: endStr, end_date: startStr });
+              return;
+            }
+
+            updateFilters({ start_date: startStr, end_date: endStr });
+          }}
+        />
+      </div>
+
+      {/* 검색 */}
+      <div className="mt-2 min-w-[180px] flex-1">
+        <Input placeholder="검색..." className="h-9" />
+      </div>
+    </section>
   );
 }

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -18,7 +18,7 @@ export default function FixedCostsList({ items }: { items: IFixedRule[] }) {
           </div>
         )}
 
-        <div className={isFiltering ? 'hidden' : ''}>
+        <div className={isFiltering ? 'hidden' : 'space-y-6'}>
           {items.length === 0 ? (
             <p className="text-muted-foreground text-center">
               등록된 고정비가 없습니다

--- a/fe/src/components/fixed-costs/FixedCostsList.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsList.tsx
@@ -3,26 +3,36 @@
 import { useFixedCosts } from '@/app/(app)/fixed-costs/FixedCostsContext';
 import FixedCostItem from './FixedCostItem';
 import { IFixedRule } from '@/types/fixed-costs';
+import { Spinner } from '../ui/spinner';
 
 export default function FixedCostsList({ items }: { items: IFixedRule[] }) {
-  const { openEdit } = useFixedCosts();
+  const { openEdit, isFiltering } = useFixedCosts();
 
   return (
     <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
       <div className="w-full max-w-xl space-y-6">
-        {items.length === 0 ? (
-          <p className="text-muted-foreground text-center">
-            등록된 고정비가 없습니다
-          </p>
-        ) : (
-          items.map((rule) => (
-            <FixedCostItem
-              key={rule.id}
-              rule={rule}
-              onEdit={() => openEdit(rule)}
-            />
-          ))
+        {isFiltering && (
+          <div className="text-muted-foreground flex animate-pulse items-center justify-center gap-4 py-12">
+            <Spinner className="size-6" />
+            <span className="text-base">Loading...</span>
+          </div>
         )}
+
+        <div className={isFiltering ? 'hidden' : ''}>
+          {items.length === 0 ? (
+            <p className="text-muted-foreground text-center">
+              등록된 고정비가 없습니다
+            </p>
+          ) : (
+            items.map((rule) => (
+              <FixedCostItem
+                key={rule.id}
+                rule={rule}
+                onEdit={() => openEdit(rule)}
+              />
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
@@ -15,7 +15,7 @@ const FixedCostItemSkeleton = () => (
         <Skeleton className="h-5 w-28 rounded-md" />
       </div>
 
-      <div className="flex flex-row items-center">
+      <div className="flex flex-row items-center pr-5">
         {/* 좌측: 주기 + 금액 */}
         <div className="flex w-32 flex-col gap-1">
           <Skeleton className="h-3 w-20" />
@@ -35,7 +35,7 @@ const FixedCostItemSkeleton = () => (
     </ItemContent>
     {/* 우측: chevron 자리 */}
     <div className="absolute top-1/2 right-3 -translate-y-1/2">
-      <Skeleton className="h-5 w-5" />
+      <Skeleton className="h-6 w-6" />
     </div>
   </Item>
 );

--- a/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsListSkeleton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Item, ItemContent, ItemTitle } from '@/components/ui/item';
+import { Item, ItemContent } from '@/components/ui/item';
 import { Skeleton } from '@/components/ui/skeleton';
 
 type Props = {
@@ -8,29 +8,35 @@ type Props = {
 };
 
 const FixedCostItemSkeleton = () => (
-  <Item variant="outline">
-    <ItemContent className="flex flex-row items-center">
-      {/* 좌측: 주기 + 금액 */}
-      <div className="flex w-32 flex-col gap-2">
-        <Skeleton className="h-3 w-20" />
-        <Skeleton className="h-4 w-28" />
+  <Item variant="outline" className="relative">
+    <ItemContent className="flex flex-col gap-2">
+      {/* 상단: 기간/상태 뱃지 영역 */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Skeleton className="h-5 w-28 rounded-md" />
       </div>
 
-      {/* 중앙: 카테고리 + 제목 */}
-      <div className="pl-2">
-        <ItemTitle className="pl-2">
-          <Skeleton className="h-3 w-24" />
-        </ItemTitle>
-        <ItemTitle className="p-2">
-          <Skeleton className="h-4 w-40" />
-        </ItemTitle>
-      </div>
+      <div className="flex flex-row items-center">
+        {/* 좌측: 주기 + 금액 */}
+        <div className="flex w-32 flex-col gap-1">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-4 w-28" />
+        </div>
 
-      {/* 우측: chevron 자리 */}
-      <div className="ml-auto">
-        <Skeleton className="h-8 w-8" />
+        {/* 중앙: 카테고리 + 제목 */}
+        <div className="min-w-0 flex-1 gap-2 pl-2">
+          <div className="text-sm">
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <div className="mt-1">
+            <Skeleton className="h-5 w-2/3" />
+          </div>
+        </div>
       </div>
     </ItemContent>
+    {/* 우측: chevron 자리 */}
+    <div className="absolute top-1/2 right-3 -translate-y-1/2">
+      <Skeleton className="h-5 w-5" />
+    </div>
   </Item>
 );
 

--- a/fe/src/components/fixed-costs/RangeDatePicker.tsx
+++ b/fe/src/components/fixed-costs/RangeDatePicker.tsx
@@ -66,8 +66,8 @@ export default function RangeDatePicker({
       </PopoverTrigger>
 
       <PopoverContent
-        className="border-brand-soft/20 w-auto rounded-2xl p-4 shadow-xl"
-        align="start"
+        className="border-brand-soft/20 w-auto p-2 shadow-xl"
+        align="center"
       >
         <Calendar
           mode="range"
@@ -98,12 +98,9 @@ export default function RangeDatePicker({
           className="rounded-md border-none"
         />
 
-        <div className="border-brand-subtle mt-4 flex items-center justify-between gap-4 border-t pt-4">
+        <div className="border-brand-subtle mt-2 flex items-center justify-between gap-4 border-t px-2 pt-2">
           <div className="flex items-center gap-3">
-            <Label
-              htmlFor="end-date-toggle"
-              className="text-brand-strong text-sm"
-            >
+            <Label htmlFor="end-date-toggle" className="text-sm font-normal">
               종료일 설정
             </Label>
             <Switch

--- a/fe/src/components/fixed-costs/RangeDatePicker.tsx
+++ b/fe/src/components/fixed-costs/RangeDatePicker.tsx
@@ -59,10 +59,10 @@ export default function RangeDatePicker({
         <Button
           type="button"
           variant="outline"
-          className="w-[260px] justify-start text-left font-normal"
+          className="min-w-[180px] flex-1 justify-start text-left"
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
-          <span>{label}</span>
+          <span className={!start ? 'text-muted-foreground' : ''}>{label}</span>
         </Button>
       </PopoverTrigger>
 

--- a/fe/src/components/fixed-costs/RangeDatePicker.tsx
+++ b/fe/src/components/fixed-costs/RangeDatePicker.tsx
@@ -118,7 +118,7 @@ export default function RangeDatePicker({
             onClick={() =>
               onChange({ start: undefined, end: undefined, endEnabled: false })
             }
-            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-subtle text-xs"
+            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-subtle text-xs dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
           >
             <RotateCcw className="mr-1 h-3 w-3" />
             초기화

--- a/fe/src/components/fixed-costs/RangeDatePicker.tsx
+++ b/fe/src/components/fixed-costs/RangeDatePicker.tsx
@@ -10,9 +10,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { CalendarIcon } from 'lucide-react';
+import { CalendarIcon, RotateCcw } from 'lucide-react';
 import { formatLocalDate } from '@/utils/date';
 import type { DateRange } from 'react-day-picker';
+import { cn } from '@/lib/utils';
 
 type Props = {
   start?: Date;
@@ -34,23 +35,19 @@ export default function RangeDatePicker({
   const label = React.useMemo(() => {
     if (!start) return '기간 선택';
     if (!endEnabled || !end) return formatLocalDate(start);
-    return `${formatLocalDate(start)} → ${formatLocalDate(end)}`;
+    return `${formatLocalDate(start)} ~ ${formatLocalDate(end)}`;
   }, [start, end, endEnabled]);
 
   const handleToggleEnd = (checked: boolean) => {
     if (!checked) {
-      // 종료일 기능 OFF : end 제거
       onChange({ start, end: undefined, endEnabled: false });
       return;
     }
-
-    // 종료일 기능 ON : start가 있으면 end 기본값을 start로 설정
-    if (start) {
-      onChange({ start, end: end ?? start, endEnabled: true });
-    } else {
-      // start가 없으면 토글만 켜두고, 사용자가 날짜를 찍으면 start부터 잡히게
+    if (!start) {
       onChange({ start: undefined, end: undefined, endEnabled: true });
+      return;
     }
+    onChange({ start, end: end ?? start, endEnabled: true });
   };
 
   return (
@@ -59,14 +56,19 @@ export default function RangeDatePicker({
         <Button
           type="button"
           variant="outline"
-          className="min-w-[180px] flex-1 justify-start text-left"
+          className={cn(
+            'ring-brand-neutral/20 focus:ring-brand min-w-[220px] flex-1 justify-start border-none bg-white ring-1 hover:bg-white'
+          )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          <span className={!start ? 'text-muted-foreground' : ''}>{label}</span>
+          <CalendarIcon className={'text-brand mr-0.5 h-4 w-4 opacity-60'} />
+          <span className="font-normal">{label}</span>
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-auto p-3" align="start">
+      <PopoverContent
+        className="border-brand-soft/20 w-auto rounded-2xl p-4 shadow-xl"
+        align="start"
+      >
         <Calendar
           mode="range"
           selected={selected}
@@ -93,12 +95,23 @@ export default function RangeDatePicker({
             });
           }}
           numberOfMonths={1}
+          className="rounded-md border-none"
         />
 
-        <div className="mt-3 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Label className="text-sm">종료일</Label>
-            <Switch checked={endEnabled} onCheckedChange={handleToggleEnd} />
+        <div className="border-brand-subtle mt-4 flex items-center justify-between gap-4 border-t pt-4">
+          <div className="flex items-center gap-3">
+            <Label
+              htmlFor="end-date-toggle"
+              className="text-brand-strong text-sm"
+            >
+              종료일 설정
+            </Label>
+            <Switch
+              id="end-date-toggle"
+              checked={endEnabled}
+              onCheckedChange={handleToggleEnd}
+              className="data-[state=checked]:bg-brand"
+            />
           </div>
 
           <Button
@@ -108,7 +121,9 @@ export default function RangeDatePicker({
             onClick={() =>
               onChange({ start: undefined, end: undefined, endEnabled: false })
             }
+            className="text-brand-neutral hover:text-brand-strong hover:bg-brand-subtle text-xs"
           >
+            <RotateCcw className="mr-1 h-3 w-3" />
             초기화
           </Button>
         </div>

--- a/fe/src/components/fixed-costs/RangeDatePicker.tsx
+++ b/fe/src/components/fixed-costs/RangeDatePicker.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { CalendarIcon } from 'lucide-react';
+import { formatLocalDate } from '@/utils/date';
+import type { DateRange } from 'react-day-picker';
+
+type Props = {
+  start?: Date;
+  end?: Date;
+  endEnabled: boolean;
+  onChange: (next: { start?: Date; end?: Date; endEnabled: boolean }) => void;
+};
+
+export default function RangeDatePicker({
+  start,
+  end,
+  endEnabled,
+  onChange,
+}: Props) {
+  const selected: DateRange | undefined = start
+    ? { from: start, to: endEnabled ? end : undefined }
+    : undefined;
+
+  const label = React.useMemo(() => {
+    if (!start) return '기간 선택';
+    if (!endEnabled || !end) return formatLocalDate(start);
+    return `${formatLocalDate(start)} → ${formatLocalDate(end)}`;
+  }, [start, end, endEnabled]);
+
+  const handleToggleEnd = (checked: boolean) => {
+    if (!checked) {
+      // 종료일 기능 OFF : end 제거
+      onChange({ start, end: undefined, endEnabled: false });
+      return;
+    }
+
+    // 종료일 기능 ON : start가 있으면 end 기본값을 start로 설정
+    if (start) {
+      onChange({ start, end: end ?? start, endEnabled: true });
+    } else {
+      // start가 없으면 토글만 켜두고, 사용자가 날짜를 찍으면 start부터 잡히게
+      onChange({ start: undefined, end: undefined, endEnabled: true });
+    }
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-[260px] justify-start text-left font-normal"
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          <span>{label}</span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-auto p-3" align="start">
+        <Calendar
+          mode="range"
+          selected={selected}
+          onSelect={(range) => {
+            if (!range?.from) return;
+
+            // 토글 OFF면 단일 날짜처럼 from만 유지
+            if (!endEnabled) {
+              onChange({
+                start: range.from,
+                end: undefined,
+                endEnabled: false,
+              });
+              return;
+            }
+
+            // 토글 ON이면 range 유지
+            // 1번 클릭: from만 생김 (to 없음)
+            // 2번 클릭: to 생김
+            onChange({
+              start: range.from,
+              end: range.to ?? undefined,
+              endEnabled: true,
+            });
+          }}
+          numberOfMonths={1}
+        />
+
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Label className="text-sm">종료일</Label>
+            <Switch checked={endEnabled} onCheckedChange={handleToggleEnd} />
+          </div>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              onChange({ start: undefined, end: undefined, endEnabled: false })
+            }
+          >
+            초기화
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/fe/src/hooks/useFixedCostsFilters.ts
+++ b/fe/src/hooks/useFixedCostsFilters.ts
@@ -18,5 +18,17 @@ export function useFixedCostsFilters() {
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   };
 
-  return { searchParams, updateFilter };
+  const updateFilters = (next: Record<string, string | undefined | null>) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    Object.entries(next).forEach(([key, value]) => {
+      if (!value || value === 'all') params.delete(key);
+      else params.set(key, value);
+    });
+
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  return { searchParams, updateFilter, updateFilters };
 }

--- a/fe/src/hooks/useFixedCostsFilters.ts
+++ b/fe/src/hooks/useFixedCostsFilters.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+export function useFixedCostsFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    // all 또는 빈 값이면 query param 제거
+    if (!value || value === 'all') params.delete(key);
+    else params.set(key, value);
+
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  return { searchParams, updateFilter };
+}

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -1,5 +1,5 @@
 import { getMonthRange } from '@/utils/date';
-import type { IFixedRule } from '@/types/fixed-costs';
+import type { FixedCostsFilters, IFixedRule } from '@/types/fixed-costs';
 import { requireUserServer } from '@/utils/supabase/requireUserServer';
 
 // group_id별 대표 rule 선택
@@ -21,7 +21,9 @@ const pickRepresentativeRule = (rules: IFixedRule[]) => {
 };
 
 // 고정비 규칙 목록 조회
-export const fetchFixedRulesServer = async () => {
+export const fetchFixedRulesServer = async (
+  filters: FixedCostsFilters = {}
+) => {
   const { supabase, user } = await requireUserServer();
 
   const { data, error } = await supabase
@@ -32,7 +34,14 @@ export const fetchFixedRulesServer = async () => {
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-  const rules = (data ?? []) as IFixedRule[];
+
+  // 필터링 전 전체 데이터
+  let rules = (data ?? []) as IFixedRule[];
+
+  // 필터링 적용
+  if (filters.type) {
+    rules = rules.filter((r) => r.type === filters.type);
+  }
 
   // group_id가 아직 없는 데이터 대비 대표 rule 선택
   const groupMap = new Map<string, IFixedRule[]>();

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -1,6 +1,10 @@
-import { getMonthRange } from '@/utils/date';
+import { getMonthRange, parseLocalDate } from '@/utils/date';
 import type { FixedCostsFilters, IFixedRule } from '@/types/fixed-costs';
 import { requireUserServer } from '@/utils/supabase/requireUserServer';
+import {
+  hasMonthlyOccurrence,
+  hasWeeklyOccurrence,
+} from '@/utils/fixed-costs/period';
 
 // group_id별 대표 rule 선택
 const pickRepresentativeRule = (rules: IFixedRule[]) => {
@@ -44,6 +48,20 @@ export const fetchFixedRulesServer = async (
   }
   if (filters.cycle) {
     rules = rules.filter((r) => r.cycle === filters.cycle);
+  }
+  const rangeStart = parseLocalDate(filters.start_date);
+  const rangeEnd = parseLocalDate(filters.end_date);
+
+  if (rangeStart && rangeEnd) {
+    rules = rules.filter((rule) => {
+      if (rule.cycle === 'MONTHLY') {
+        return hasMonthlyOccurrence(rule, rangeStart, rangeEnd);
+      }
+      if (rule.cycle === 'WEEKLY') {
+        return hasWeeklyOccurrence(rule, rangeStart, rangeEnd);
+      }
+      return false;
+    });
   }
 
   // group_id가 아직 없는 데이터 대비 대표 rule 선택

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -63,6 +63,10 @@ export const fetchFixedRulesServer = async (
       return false;
     });
   }
+  if (filters.query) {
+    const q = filters.query.toLowerCase();
+    rules = rules.filter((rule) => rule.title.toLowerCase().includes(q));
+  }
 
   // group_id가 아직 없는 데이터 대비 대표 rule 선택
   const groupMap = new Map<string, IFixedRule[]>();

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -42,6 +42,9 @@ export const fetchFixedRulesServer = async (
   if (filters.type) {
     rules = rules.filter((r) => r.type === filters.type);
   }
+  if (filters.cycle) {
+    rules = rules.filter((r) => r.cycle === filters.cycle);
+  }
 
   // group_id가 아직 없는 데이터 대비 대표 rule 선택
   const groupMap = new Map<string, IFixedRule[]>();

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -30,25 +30,21 @@ export const fetchFixedRulesServer = async (
 ) => {
   const { supabase, user } = await requireUserServer();
 
-  const { data, error } = await supabase
-    .from('fixed_rules')
-    .select('*')
-    .eq('user_id', user.id)
+  let q = supabase.from('fixed_rules').select('*').eq('user_id', user.id);
+
+  // 필터링 조건 적용
+  if (filters.type) q = q.eq('type', filters.type);
+  if (filters.cycle) q = q.eq('cycle', filters.cycle);
+  if (filters.query) q = q.ilike('title', `%${filters.query}%`);
+
+  const { data, error } = await q
     .order('start_date', { ascending: false })
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-
-  // 필터링 전 전체 데이터
   let rules = (data ?? []) as IFixedRule[];
 
-  // 필터링 적용
-  if (filters.type) {
-    rules = rules.filter((r) => r.type === filters.type);
-  }
-  if (filters.cycle) {
-    rules = rules.filter((r) => r.cycle === filters.cycle);
-  }
+  // 기간 필터링 적용
   const rangeStart = parseLocalDate(filters.start_date);
   const rangeEnd = parseLocalDate(filters.end_date);
 
@@ -62,10 +58,6 @@ export const fetchFixedRulesServer = async (
       }
       return false;
     });
-  }
-  if (filters.query) {
-    const q = filters.query.toLowerCase();
-    rules = rules.filter((rule) => rule.title.toLowerCase().includes(q));
   }
 
   // group_id가 아직 없는 데이터 대비 대표 rule 선택

--- a/fe/src/services/fixed-costs/fixedCostsServer.ts
+++ b/fe/src/services/fixed-costs/fixedCostsServer.ts
@@ -48,13 +48,15 @@ export const fetchFixedRulesServer = async (
   const rangeStart = parseLocalDate(filters.start_date);
   const rangeEnd = parseLocalDate(filters.end_date);
 
-  if (rangeStart && rangeEnd) {
+  if (rangeStart) {
+    const effectiveEnd = rangeEnd ?? new Date(2100, 0, 1);
+
     rules = rules.filter((rule) => {
       if (rule.cycle === 'MONTHLY') {
-        return hasMonthlyOccurrence(rule, rangeStart, rangeEnd);
+        return hasMonthlyOccurrence(rule, rangeStart, effectiveEnd);
       }
       if (rule.cycle === 'WEEKLY') {
-        return hasWeeklyOccurrence(rule, rangeStart, rangeEnd);
+        return hasWeeklyOccurrence(rule, rangeStart, effectiveEnd);
       }
       return false;
     });

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -55,4 +55,5 @@ export type FixedCostsFilters = {
   cycle?: 'WEEKLY' | 'MONTHLY';
   start_date?: string;
   end_date?: string;
+  query?: string;
 };

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -53,4 +53,6 @@ export type FixedTransactionInsert = {
 export type FixedCostsFilters = {
   type?: 'income' | 'expense';
   cycle?: 'WEEKLY' | 'MONTHLY';
+  start_date?: string;
+  end_date?: string;
 };

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -48,3 +48,8 @@ export type FixedTransactionInsert = {
   amount: number;
   category_id: string;
 };
+
+// 고정비 규칙 필터링 타입
+export type FixedCostsFilters = {
+  type?: 'income' | 'expense';
+};

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -52,4 +52,5 @@ export type FixedTransactionInsert = {
 // 고정비 규칙 필터링 타입
 export type FixedCostsFilters = {
   type?: 'income' | 'expense';
+  cycle?: 'WEEKLY' | 'MONTHLY';
 };

--- a/fe/src/utils/fixed-costs/fixedCosts.ts
+++ b/fe/src/utils/fixed-costs/fixedCosts.ts
@@ -1,6 +1,6 @@
 import { IFixedCostFormData } from '@/hooks/useFixedCostForm';
 import { ApplyScope, IFixedRule } from '@/types/fixed-costs';
-import { formatLocalDate, parseLocalDate } from '../date';
+import { parseLocalDate } from '../date';
 import {
   startOfMonth,
   endOfMonth,

--- a/fe/src/utils/fixed-costs/period.ts
+++ b/fe/src/utils/fixed-costs/period.ts
@@ -26,3 +26,70 @@ export function getNextPeriodStartDate(cycle: IFixedRule['cycle']) {
   end.setDate(end.getDate() + 1);
   return formatLocalDate(end);
 }
+
+// 특정 날짜의 고정비 규칙 활성 여부 확인
+export const isRuleActiveOn = (rule: IFixedRule, date: Date): boolean => {
+  const ruleStart = parseLocalDate(rule.start_date)!;
+  const ruleEnd = rule.end_date ? parseLocalDate(rule.end_date)! : null;
+
+  if (date < ruleStart) return false;
+  if (ruleEnd && date > ruleEnd) return false;
+
+  return true;
+};
+
+// 특정 기간 내에 월간 규칙이 발생하는지 확인
+export const hasMonthlyOccurrence = (
+  rule: IFixedRule,
+  rangeStart: Date,
+  rangeEnd: Date
+): boolean => {
+  if (!rule.monthday) return false;
+
+  // rangeStart가 속한 달부터 rangeEnd가 속한 달까지 월 단위 순회
+  let cursor = new Date(rangeStart.getFullYear(), rangeStart.getMonth(), 1);
+  const endMonth = new Date(rangeEnd.getFullYear(), rangeEnd.getMonth(), 1);
+
+  while (cursor <= endMonth) {
+    const year = cursor.getFullYear();
+    const month = cursor.getMonth();
+    const lastDayOfMonth = new Date(year, month + 1, 0).getDate();
+
+    // monthday가 실제로 존재하는 날짜일 때만 발생 가능
+    if (rule.monthday <= lastDayOfMonth) {
+      const occurrenceDate = new Date(year, month, rule.monthday);
+
+      if (
+        occurrenceDate >= rangeStart &&
+        occurrenceDate <= rangeEnd &&
+        isRuleActiveOn(rule, occurrenceDate)
+      ) {
+        return true;
+      }
+    }
+
+    // 다음 달로 이동
+    cursor = new Date(year, month + 1, 1);
+  }
+
+  return false;
+};
+
+// 특정 기간 내에 주간 규칙이 발생하는지 확인
+export const hasWeeklyOccurrence = (
+  rule: IFixedRule,
+  rangeStart: Date,
+  rangeEnd: Date
+): boolean => {
+  if (rule.weekday == null) return false;
+
+  const startWeekday = rangeStart.getDay();
+  const diff = (rule.weekday - startWeekday + 7) % 7;
+
+  const firstOccurrence = new Date(rangeStart);
+  firstOccurrence.setDate(rangeStart.getDate() + diff);
+
+  if (firstOccurrence > rangeEnd) return false;
+
+  return isRuleActiveOn(rule, firstOccurrence);
+};


### PR DESCRIPTION
## PR 개요
고정비 관리 페이지에 필터링 기능(타입/주기/기간/검색) 을 추가하고, 조건 적용 시 로딩 상태 UX를 개선했습니다.

## 변경 사항
### 1. 고정비 필터 기능 추가
- 타입(전체/수입/지출), 반복 주기(전체/월간/주간) 필터 추가
- 기간 필터 (시작일/종료일) Range Date Picker 구현
- 검색어 기반 필터링 추가
- 필터 상태를 URL 기준으로 관리하여 새로고침/뒤로가기 등 대응 가능
### 2. 필터 적용 시 로딩 UX 개선
- 조건 적용하기 버튼 클릭 시 버튼 비활성화 및 리스트 영역에 로딩 스피너 표시
- 필터 적용 중에는 기존 리스트를 숨기고 로딩 상태만 노출
- 최초 진입 시에는 기존 리스트 스켈레톤 유지

## 스크린샷 
### 고정비 필터링 영역
before | after
-- | --
<img height="600" src="https://github.com/user-attachments/assets/7df7f6af-bbf4-42db-9197-3a054e4b9a14" /> | <img height="600" src="https://github.com/user-attachments/assets/3952394f-e5fa-40fa-8246-112a2dbf92d3" />
### 고정비 개별 항목
before | after
-- | --
<img height="360" src="https://github.com/user-attachments/assets/050b9b29-1bd2-4ab7-9058-a86b1d07f6da" /> | <img height="360" src="https://github.com/user-attachments/assets/097117e3-212b-46ae-85fe-28d52a1f493a" />

## 리뷰 요청 사항
- 타입/주기/기간/검색어 필터링이 제대로 동작하는지 확인 부탁드립니다.

## 추후 할 일
- [x] 예정 고정비 표시 #126 