### PR TITLE
[feat] 캘린더 일일 거래 내역에 예정 고정비 표시

### DIFF
--- a/fe/src/app/(app)/history/actions.ts
+++ b/fe/src/app/(app)/history/actions.ts
@@ -4,6 +4,8 @@ import { formatLocalDate, parseLocalDate } from '@/utils/date';
 import { requireUserServer } from '@/utils/supabase/requireUserServer';
 import { revalidatePath } from 'next/cache';
 import { getMonthRange } from '@/utils/date';
+import { fetchFixedRulesByMonthServer } from '@/services/fixed-costs/fixedCostsServer';
+import { buildScheduledFixedByDateMap } from '@/utils/fixed-costs/scheduled';
 
 export interface TransactionFilters {
   type?: 'income' | 'expense';
@@ -79,6 +81,7 @@ export const getTransaction = async (
 
   return data || [];
 };
+
 export const getMonthTransactions = async (month: string) => {
   const { supabase, user } = await requireUserServer();
 
@@ -94,7 +97,8 @@ export const getMonthTransactions = async (month: string) => {
     generateThroughDate,
   });
 
-  const { data, error } = await supabase
+  // 거래 조회
+  const { data: transactions, error } = await supabase
     .from('transactions')
     .select('*')
     .eq('user_id', user.id)
@@ -102,8 +106,27 @@ export const getMonthTransactions = async (month: string) => {
     .lte('date', endDate)
     .order('date', { ascending: false });
   if (error) throw error;
-  return data || [];
+
+  // 해당 월 고정비 규칙 조회
+  const fixedRules = await fetchFixedRulesByMonthServer(monthDate);
+
+  // 예정 고정비 맵 생성
+  const scheduledFixedByDateMap = buildScheduledFixedByDateMap({
+    monthDate,
+    today: new Date(),
+    fixedRules,
+    transactions: (transactions ?? []).map((t) => ({
+      fixed_rule_id: t.fixed_rule_id,
+      origin_date: t.origin_date,
+    })),
+  });
+
+  return {
+    transactions: transactions ?? [],
+    scheduledFixedByDateMap,
+  };
 };
+
 export async function revalidateTransactions() {
   revalidatePath('/history');
   revalidatePath('/');

--- a/fe/src/app/(app)/history/actions.ts
+++ b/fe/src/app/(app)/history/actions.ts
@@ -79,10 +79,21 @@ export const getTransaction = async (
 
   return data || [];
 };
-export const getMonthTransactions= async(month : string)=>{
+export const getMonthTransactions = async (month: string) => {
   const { supabase, user } = await requireUserServer();
-  const { startDate, endDate} = getMonthRange(new Date(`${month}-1`))
-  
+
+  const monthDate = new Date(`${month}-01`);
+  const { startDate, endDate } = getMonthRange(monthDate);
+
+  // 고정비 동기화 (오늘까지)
+  const generateThroughDate = formatLocalDate(new Date());
+  await syncByMonthServer({
+    monthDate,
+    startDate,
+    endDate,
+    generateThroughDate,
+  });
+
   const { data, error } = await supabase
     .from('transactions')
     .select('*')
@@ -90,9 +101,9 @@ export const getMonthTransactions= async(month : string)=>{
     .gte('date', startDate)
     .lte('date', endDate)
     .order('date', { ascending: false });
-    if (error) throw error;
-    return data || [];
-}
+  if (error) throw error;
+  return data || [];
+};
 export async function revalidateTransactions() {
   revalidatePath('/history');
   revalidatePath('/');

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -34,11 +34,12 @@ async function InitialDataLoader({ currentMonth }: { currentMonth: string }) {
   const currentMonthDate = new Date(today.getFullYear(), today.getMonth(), 1);
 
   // 당월 데이터 fetch
-  const [{ transactions }, budgets, fixedRules] = await Promise.all([
-    getMonthTransactions(currentMonth),
-    fetchBudgetsServer(currentMonthDate),
-    fetchFixedRulesByMonthServer(currentMonthDate),
-  ]);
+  const [{ transactions, scheduledFixedByDateMap }, budgets, fixedRules] =
+    await Promise.all([
+      getMonthTransactions(currentMonth),
+      fetchBudgetsServer(currentMonthDate),
+      fetchFixedRulesByMonthServer(currentMonthDate),
+    ]);
 
   const budget = getTotalBudgetAmount(budgets);
   const fixedPlannedThisMonth = getFixedPlannedExpenseByMonth(
@@ -110,6 +111,7 @@ async function InitialDataLoader({ currentMonth }: { currentMonth: string }) {
     <CalendarClient
       currentMonth={currentMonth}
       initialTransactions={transactions}
+      initialScheduledFixedByDateMap={scheduledFixedByDateMap}
       dailyRec={daily}
       dailyChartData={dailyChartData}
     />

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -1,4 +1,4 @@
-import { getTransaction,getMonthTransactions } from './history/actions';
+import { getTransaction, getMonthTransactions } from './history/actions';
 import { Suspense } from 'react';
 import { formatLocalDate, formatMonth } from '@/utils/date';
 import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
@@ -23,20 +23,18 @@ export default async function Home() {
   return (
     <div className="flex min-h-screen w-full max-w-6xl self-start">
       <Suspense fallback={<CalendarSkeleton />}>
-        <InitialDataLoader
-          currentMonth={currentMonth}
-        />
+        <InitialDataLoader currentMonth={currentMonth} />
       </Suspense>
     </div>
   );
 }
 
-async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
+async function InitialDataLoader({ currentMonth }: { currentMonth: string }) {
   const today = new Date();
   const currentMonthDate = new Date(today.getFullYear(), today.getMonth(), 1);
 
   // 당월 데이터 fetch
-  const [transactions, budgets, fixedRules] = await Promise.all([
+  const [{ transactions }, budgets, fixedRules] = await Promise.all([
     getMonthTransactions(currentMonth),
     fetchBudgetsServer(currentMonthDate),
     fetchFixedRulesByMonthServer(currentMonthDate),
@@ -100,7 +98,7 @@ async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
   );
 
   const dailyChartData = buildDailyRecChartData({
-    monthDate : currentMonthDate,
+    monthDate: currentMonthDate,
     transactions,
     today,
     budget,
@@ -115,5 +113,5 @@ async function InitialDataLoader({currentMonth}: {currentMonth: string} ) {
       dailyRec={daily}
       dailyChartData={dailyChartData}
     />
-  )
+  );
 }

--- a/fe/src/components/calendar/Calendar.tsx
+++ b/fe/src/components/calendar/Calendar.tsx
@@ -20,10 +20,13 @@ import { useCalendarData } from '@/hooks/useCalendarData';
 import { useCalendarNavigation } from '@/hooks/useCalendarNavigation';
 import { Spinner } from '../ui/spinner';
 import { CalendarCaption } from './CalendarCaption';
+import { ScheduledFixedByDateMap } from '@/types/fixed-costs';
+import { ScheduledFixedInfo } from './ScheduledFixedInfo';
 
 interface CalendarProps {
   currentMonth: string;
   transactions: ITransaction[];
+  scheduledFixedByDateMap: ScheduledFixedByDateMap;
   isLoading: boolean;
   onMonthChange: (month: string) => void;
   children?: React.ReactNode;
@@ -38,6 +41,7 @@ const CALENDAR_CELL_HEIGHT =
 export const Calendar = ({
   currentMonth,
   transactions,
+  scheduledFixedByDateMap,
   isLoading,
   onMonthChange,
   children,
@@ -137,6 +141,11 @@ export const Calendar = ({
 
           {panelState.view === 'list' && (
             <div>
+              {/* 예정된 고정비 표시 */}
+              <ScheduledFixedInfo
+                selectedDate={selectedDate}
+                scheduledFixedByDateMap={scheduledFixedByDateMap}
+              />
               <div className="space-y-2 p-4 md:p-6 lg:p-8">
                 <Item
                   className="cursor-pointer hover:bg-gray-100"
@@ -149,6 +158,7 @@ export const Calendar = ({
                   <ItemContent>가계부 작성하기</ItemContent>
                 </Item>
               </div>
+
               <TransactionList
                 compact={true}
                 transactions={selectedDayTransactions}

--- a/fe/src/components/calendar/CalendarClient.tsx
+++ b/fe/src/components/calendar/CalendarClient.tsx
@@ -8,9 +8,11 @@ import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
 import { useMonthTransactions } from '@/hooks/useMonthTransactions';
 import { ITransaction } from '@/types/transactions';
 import { DailyRecResult, DailyRecChartData } from '@/types/dailyRec';
+import { ScheduledFixedByDateMap } from '@/types/fixed-costs';
 interface CalendarClientProps {
   currentMonth: string;
   initialTransactions: ITransaction[];
+  initialScheduledFixedByDateMap: ScheduledFixedByDateMap;
   dailyRec: DailyRecResult;
   dailyChartData: DailyRecChartData;
 }
@@ -18,16 +20,21 @@ interface CalendarClientProps {
 export function CalendarClient({
   currentMonth,
   initialTransactions,
+  initialScheduledFixedByDateMap,
   dailyRec,
   dailyChartData,
 }: CalendarClientProps) {
   const [month, setMonth] = useState(currentMonth);
 
-  const { data: transactions, isLoading } = useMonthTransactions({
+  const { data, isLoading } = useMonthTransactions({
     month,
     currentMonth,
     initialTransactions,
+    initialScheduledFixedByDateMap,
   });
+
+  const transactions = data?.transactions ?? [];
+  const scheduledFixedByDateMap = data?.scheduledFixedByDateMap ?? {};
 
   return (
     <CalendarProvider>
@@ -35,7 +42,8 @@ export function CalendarClient({
         <div className="flex w-full flex-col gap-3">
           <Calendar
             currentMonth={month}
-            transactions={transactions || []}
+            transactions={transactions}
+            scheduledFixedByDateMap={scheduledFixedByDateMap}
             isLoading={isLoading}
             onMonthChange={setMonth}
           >

--- a/fe/src/components/calendar/ScheduledFixedInfo.tsx
+++ b/fe/src/components/calendar/ScheduledFixedInfo.tsx
@@ -1,6 +1,7 @@
-'use client';
-
-import { CalendarClock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CalendarClock, Info } from 'lucide-react';
+import { THEME_COLOR } from '@/constants/colors';
+import { CATEGORIES } from '@/constants/categories';
 import { Badge } from '@/components/ui/badge';
 import { formatLocalDate } from '@/utils/date';
 import type { ScheduledFixedByDateMap } from '@/types/fixed-costs';
@@ -15,25 +16,63 @@ export function ScheduledFixedInfo({
   if (!selectedDate) return null;
 
   const dateKey = formatLocalDate(selectedDate);
-  const scheduledItems = scheduledFixedByDateMap[dateKey] ?? [];
-  if (scheduledItems.length === 0) return null;
+  const items = scheduledFixedByDateMap[dateKey] ?? [];
+  if (items.length === 0) return null;
 
   return (
-    <div className="border-brand-soft/30 bg-brand-subtle/50 mx-4 mt-2 overflow-hidden rounded-2xl border md:mx-6 lg:mx-8">
+    <div className="border-brand-soft/30 bg-brand-subtle/50 mx-4 mt-2 overflow-hidden rounded-lg border md:mx-6 lg:mx-8">
+      {/* 헤더 */}
+      <div className="border-brand-soft/20 bg-brand-soft/10 flex items-center gap-2 border-b px-4 py-3">
+        <CalendarClock className="text-brand-strong h-4 w-4" />
+        <h4 className="text-brand-strong text-sm font-bold">예정된 고정비</h4>
+        <Badge
+          variant="outline"
+          className="border-brand-soft text-brand-strong ml-auto bg-white/50 text-xs"
+        >
+          {items.length}건
+        </Badge>
+      </div>
+
       {/* 리스트 */}
       <div className="divide-brand-soft/10 divide-y">
-        {scheduledItems.map((item, idx) => {
+        {items.map((item, idx) => {
+          const categoryName = CATEGORIES[item.type].find(
+            (cat) => cat.category_key === item.category_id
+          )?.name_ko;
           return (
             <div
               key={`${item.fixed_rule_id}-${idx}`}
               className="flex items-center justify-between p-4"
             >
               <div className="flex items-center gap-3">
-                <span className="text-sm font-bold">{item.title}</span>
+                <div
+                  className={cn(
+                    'h-8 w-1 shrink-0 rounded-full',
+                    item.type === 'income' ? 'bg-blue-400' : 'bg-red-400'
+                  )}
+                />
+
+                <div className="flex flex-col">
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground text-xs">
+                      {categoryName}
+                    </span>
+                  </div>
+                  <span className="text-sm font-semibold text-slate-700">
+                    {item.title}
+                  </span>
+                </div>
               </div>
 
-              <div className="flex items-end">
-                <span>
+              <div className="shrink-0 pl-3 text-right">
+                <span
+                  className={cn(
+                    'text-sm font-bold whitespace-nowrap tabular-nums',
+                    item.type === 'income'
+                      ? THEME_COLOR.INCOME
+                      : THEME_COLOR.EXPENSE
+                  )}
+                >
                   {item.type === 'income' ? '+' : '-'}
                   {item.amount.toLocaleString()}원
                 </span>
@@ -41,6 +80,13 @@ export function ScheduledFixedInfo({
             </div>
           );
         })}
+        {/* 하단 안내 가이드 */}
+        <div className="text-muted-foreground flex items-center gap-1.5 px-4 py-2">
+          <Info className="h-3 w-3" />
+          <p className="text-xs">
+            설정된 반복 주기에 따라 자동으로 계산된 내역입니다.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/fe/src/components/calendar/ScheduledFixedInfo.tsx
+++ b/fe/src/components/calendar/ScheduledFixedInfo.tsx
@@ -20,14 +20,14 @@ export function ScheduledFixedInfo({
   if (items.length === 0) return null;
 
   return (
-    <div className="border-brand-soft/30 bg-brand-subtle/50 mx-4 mt-2 overflow-hidden rounded-lg border md:mx-6 lg:mx-8">
+    <div className="border-brand-soft/30 dark:bg-brand-soft/5 bg-brand-subtle/50 mx-4 mt-2 overflow-hidden rounded-lg border md:mx-6 lg:mx-8">
       {/* 헤더 */}
-      <div className="border-brand-soft/20 bg-brand-soft/10 flex items-center gap-2 border-b px-4 py-3">
-        <CalendarClock className="text-brand-strong h-4 w-4" />
-        <h4 className="text-brand-strong text-sm font-bold">예정된 고정비</h4>
+      <div className="border-brand-soft/20 bg-brand-soft/10 dark:text-brand text-brand-strong dark:bg-brand-soft/5 flex items-center gap-2 border-b px-4 py-3">
+        <CalendarClock className="h-4 w-4" />
+        <h4 className="text-sm font-bold">예정된 고정비</h4>
         <Badge
           variant="outline"
-          className="border-brand-soft text-brand-strong ml-auto bg-white/50 text-xs"
+          className="border-brand-soft text-brand-strong dark:text-brand-soft ml-auto bg-white/50 text-xs dark:bg-transparent"
         >
           {items.length}건
         </Badge>
@@ -58,7 +58,7 @@ export function ScheduledFixedInfo({
                       {categoryName}
                     </span>
                   </div>
-                  <span className="text-sm font-semibold text-slate-700">
+                  <span className="text-foreground text-sm font-semibold">
                     {item.title}
                   </span>
                 </div>

--- a/fe/src/components/calendar/ScheduledFixedInfo.tsx
+++ b/fe/src/components/calendar/ScheduledFixedInfo.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { formatLocalDate } from '@/utils/date';
+import type { ScheduledFixedByDateMap } from '@/types/fixed-costs';
+
+export function ScheduledFixedInfo({
+  selectedDate,
+  scheduledFixedByDateMap,
+}: {
+  selectedDate: Date | null;
+  scheduledFixedByDateMap: ScheduledFixedByDateMap;
+}) {
+  if (!selectedDate) return null;
+
+  const dateKey = formatLocalDate(selectedDate);
+  const scheduledItems = scheduledFixedByDateMap[dateKey] ?? [];
+  if (scheduledItems.length === 0) return null;
+
+  return (
+    <div className="border-brand-soft/30 bg-brand-subtle/50 mx-4 mt-2 overflow-hidden rounded-2xl border md:mx-6 lg:mx-8">
+      {/* 리스트 */}
+      <div className="divide-brand-soft/10 divide-y">
+        {scheduledItems.map((item, idx) => {
+          return (
+            <div
+              key={`${item.fixed_rule_id}-${idx}`}
+              className="flex items-center justify-between p-4"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-bold">{item.title}</span>
+              </div>
+
+              <div className="flex items-end">
+                <span>
+                  {item.type === 'income' ? '+' : '-'}
+                  {item.amount.toLocaleString()}원
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/fe/src/hooks/useMonthTransactions.ts
+++ b/fe/src/hooks/useMonthTransactions.ts
@@ -3,23 +3,37 @@
 import { useQuery } from '@tanstack/react-query';
 import { getMonthTransactions } from '@/app/(app)/history/actions';
 import { ITransaction } from '@/types/transactions';
+import { ScheduledFixedByDateMap } from '@/types/fixed-costs';
 
 interface MonthTransactionsProps {
   month: string;
   currentMonth: string;
   initialTransactions?: ITransaction[];
+  initialScheduledFixedByDateMap?: ScheduledFixedByDateMap;
 }
+
+type MonthTransactionsData = {
+  transactions: ITransaction[];
+  scheduledFixedByDateMap: ScheduledFixedByDateMap;
+};
 
 export function useMonthTransactions({
   month,
   currentMonth,
   initialTransactions,
+  initialScheduledFixedByDateMap,
 }: MonthTransactionsProps) {
-  return useQuery({
+  return useQuery<MonthTransactionsData>({
     queryKey: ['transactions', month],
     queryFn: () => getMonthTransactions(month),
-    initialData: month === currentMonth ? initialTransactions : undefined,
+    initialData:
+      month === currentMonth
+        ? {
+            transactions: initialTransactions ?? [],
+            scheduledFixedByDateMap: initialScheduledFixedByDateMap ?? {},
+          }
+        : undefined,
     staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 30 * 60 * 1000,   // 30 minutes
+    gcTime: 30 * 60 * 1000, // 30 minutes
   });
 }

--- a/fe/src/types/fixed-costs.ts
+++ b/fe/src/types/fixed-costs.ts
@@ -57,3 +57,15 @@ export type FixedCostsFilters = {
   end_date?: string;
   query?: string;
 };
+
+// 예정된 고정비 정보 타입
+export type ScheduledFixedInfo = {
+  fixed_rule_id: string;
+  title: string;
+  amount: number;
+  type: 'income' | 'expense';
+  category_id: string;
+};
+
+// 날짜별 예정된 고정비 정보 맵 타입
+export type ScheduledFixedByDateMap = Record<string, ScheduledFixedInfo[]>;

--- a/fe/src/types/transactions.ts
+++ b/fe/src/types/transactions.ts
@@ -4,6 +4,7 @@ export interface ITransaction {
   user_id: string;
   category_id: string;
   type: 'income' | 'expense';
+  origin_date: string;
   date: string;
   amount: number;
   fixed_rule_id: string | null;

--- a/fe/src/utils/fixed-costs/scheduled.ts
+++ b/fe/src/utils/fixed-costs/scheduled.ts
@@ -1,0 +1,75 @@
+import type { IFixedRule } from '@/types/fixed-costs';
+import type { ITransaction } from '@/types/transactions';
+import type {
+  ScheduledFixedInfo,
+  ScheduledFixedByDateMap,
+} from '@/types/fixed-costs';
+import { getFixedRuleDates } from '@/services/fixed-costs/getRuleDates';
+import { formatLocalDate } from '@/utils/date';
+
+// 월 단위 예정 고정비 안내 데이터 생성
+export function buildScheduledFixedByDateMap({
+  monthDate,
+  today,
+  fixedRules,
+  transactions,
+}: {
+  monthDate: Date;
+  today: Date;
+  fixedRules: IFixedRule[];
+  transactions: Pick<ITransaction, 'fixed_rule_id' | 'origin_date'>[];
+}): ScheduledFixedByDateMap {
+  const result: ScheduledFixedByDateMap = {};
+
+  // 과거 달이면 예정 고정비 없음
+  if (isBeforeMonth(monthDate, today)) {
+    return result;
+  }
+
+  const todayStr = formatLocalDate(today);
+
+  // 이미 생성된 고정비 거래 set
+  const existingOccurrenceSet = new Set<string>();
+  for (const tx of transactions) {
+    if (!tx.fixed_rule_id || !tx.origin_date) continue;
+    existingOccurrenceSet.add(`${tx.fixed_rule_id}__${tx.origin_date}`);
+  }
+
+  for (const rule of fixedRules) {
+    // 해당 월에 발생하는 날짜들
+    const dates = getFixedRuleDates(rule, monthDate);
+
+    for (const date of dates) {
+      // 현재 달이면 오늘 포함 과거 날짜 제외
+      if (isSameMonth(monthDate, today) && date <= todayStr) continue;
+
+      const occurrenceKey = `${rule.id}__${date}`;
+
+      // 이미 생성된 거래가 있으면 예정 표시하지 않음
+      if (existingOccurrenceSet.has(occurrenceKey)) continue;
+
+      const info: ScheduledFixedInfo = {
+        fixed_rule_id: rule.id,
+        title: rule.title,
+        amount: rule.amount,
+        type: rule.type,
+        category_id: rule.category_id,
+      };
+
+      (result[date] ??= []).push(info);
+    }
+  }
+
+  return result;
+}
+
+function isSameMonth(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+function isBeforeMonth(a: Date, b: Date) {
+  return (
+    a.getFullYear() < b.getFullYear() ||
+    (a.getFullYear() === b.getFullYear() && a.getMonth() < b.getMonth())
+  );
+}


### PR DESCRIPTION
## PR 개요
캘린더 날짜 상세 패널에서 미래에 예정된 고정비를 안내용 UI로 표시하는 기능을 추가했습니다.

## 변경 사항
### 1. 월 단위 예정 고정비 데이터 생성 및 전달
- `utils/fixed-costs/scheduled.ts`
    - 고정비 규칙(`fixed_rules`)을 기준으로 **선택한 월의 예정 고정비를 날짜별로 계산**하는 유틸 함수 추가
    - 과거 달 / 현재 달(today 기준) / 미래 달에 따라 예정 고정비 표시 여부를 분기 처리
- `app/history/actions.ts`
    - 월 데이터 조회 시 `transactions`와 함께 `scheduledFixedByDateMap`을 함께 반환하도록 서버 액션 확장
    - 고정비 동기화는 기존 정책대로 **오늘까지**만 생성되도록 유지
- `hooks/useMonthTransactions.ts`
    - 기존 `useMonthTransactions` 훅의 `queryKey`와 사용 방식은 유지하면서, 월 데이터에 **예정 고정비 맵(`scheduledFixedByDateMap`)을 함께 관리**하도록 확장
### 2. 날짜 상세 패널에 예정 고정비 안내 UI 추가
- `app/page.tsx` (홈 페이지)
    - 초기 렌더 시 월 데이터와 함께 `scheduledFixedByDateMap`을 조회하여 `CalendarClient`로 전달하도록 수정
- `CalendarClient.tsx`
    - 월 변경 시 `useMonthTransactions` 훅을 통해 `transactions`와 `scheduledFixedByDateMap`을 함께 받아 `Calendar` 컴포넌트로 전달
- `Calendar.tsx`
    - 날짜 선택 시 열리는 상세 패널(list view)에 예정 고정비 안내 섹션을 추가하여 실제 거래 리스트와 분리해 표시
- `ScheduledFixedInfo.tsx`
    - 선택한 날짜 기준으로 예정된 고정비를 렌더링하는 전용 UI 컴포넌트 추가
    - 안내용 UI로만 제공되며 클릭/수정/삭제 동작은 지원하지 않음

## 스크린샷
before | after
-- | --
<img width="360" height="432" alt="스크린샷 2026-01-27 17 31 23" src="https://github.com/user-attachments/assets/2b561ac3-fd6e-485f-a263-79a89366b9e8" />| <img width="360" height="432" alt="스크린샷 2026-01-27 17 30 45" src="https://github.com/user-attachments/assets/8a3b9276-9d4f-4a91-b686-47f4936866c0" />

## 리뷰 요청 사항
- 예정된 고정비가 미래 날짜에 정상적으로 표시되는지 확인 부탁드립니다.
- 과거 달, 그리고 현재 달의 오늘 이전 날짜에서는 예정된 고정비가 표시되지 않는지 확인 부탁드립니다.

## 추후 할 일
- [x] 프로필 DB 조회 최소화 #131 #138 