### PR TITLE
[feat] 분석 페이지 차트 개선

### DIFF
--- a/fe/src/components/analysis/AnalysisView.tsx
+++ b/fe/src/components/analysis/AnalysisView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AnalysisData, TransactionType } from '@/types/analysis';
+import { Info, PieChart } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { ANALYSIS_CONFIG } from '@/constants/analysis';
@@ -10,7 +11,8 @@ import { Button } from '@/components/ui/button';
 import CategoryAnalysisList from '@/components/analysis/CategoryAnalysisList';
 import CategoryChart from '@/components/analysis/CategoryChart';
 import Link from 'next/link';
-import { PieChart } from 'lucide-react';
+import { Separator } from '@/components/ui/separator';
+import WeeklyChart from '@/components/analysis/WeeklyChart';
 import { getMonthRange } from '@/utils/date';
 
 type AnalysisViewProps = {
@@ -83,6 +85,19 @@ const AnalysisView = ({
                   {diff > 0 ? config.increaseText : config.decreaseText}
                 </p>
               )}
+            </div>
+
+            <Separator className="my-6" />
+
+            {/* 주간 차트 */}
+            <div className="space-y-3">
+              <p className="font-semibold md:text-lg">주간 {config.label}</p>
+
+              <WeeklyChart
+                transactions={current}
+                selectedDate={selectedDate}
+                type={type}
+              />
             </div>
           </AnalysisSection>
 

--- a/fe/src/components/analysis/AnalysisView.tsx
+++ b/fe/src/components/analysis/AnalysisView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnalysisData, TransactionType } from '@/types/analysis';
-import { getMonthRange, getWeeksInMonth } from '@/utils/date';
+import { formatLocalDate, getMonthRange, getWeeksInMonth } from '@/utils/date';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ANALYSIS_CONFIG } from '@/constants/analysis';
@@ -38,6 +38,7 @@ const AnalysisView = ({
   // 주차별 데이터 가공
   const weeklyData = useMemo(() => {
     const weeks = getWeeksInMonth(selectedDate);
+    const todayStr = formatLocalDate(new Date());
 
     return weeks.map((week) => {
       const weekTransactions = current.filter(
@@ -55,6 +56,7 @@ const AnalysisView = ({
         transactions: weekTransactions.sort((a, b) =>
           a.date.localeCompare(b.date)
         ),
+        isCurrentWeek: todayStr >= week.startDate && todayStr <= week.endDate,
       };
     });
   }, [current, selectedDate]);
@@ -65,7 +67,10 @@ const AnalysisView = ({
   // 달이 바뀌면 선택 인덱스 초기화
   useEffect(() => {
     if (categoryData && categoryData.length > 0) setSelectedIndex(0);
-    setSelectedWeekIndex(0);
+
+    // 이번 달이라면 오늘이 포함된 주차, 아니면 1주차
+    const currentIndex = weeklyData.findIndex((w) => w.isCurrentWeek);
+    setSelectedWeekIndex(currentIndex !== -1 ? currentIndex : 0);
   }, [selectedDate]);
 
   // 선택된 월 기준으로 history 페이지 이동용 URL 생성

--- a/fe/src/components/analysis/AnalysisView.tsx
+++ b/fe/src/components/analysis/AnalysisView.tsx
@@ -11,7 +11,6 @@ import CategoryAnalysisList from '@/components/analysis/CategoryAnalysisList';
 import CategoryChart from '@/components/analysis/CategoryChart';
 import Link from 'next/link';
 import { PieChart } from 'lucide-react';
-import { Separator } from '@/components/ui/separator';
 import { getMonthRange } from '@/utils/date';
 
 type AnalysisViewProps = {
@@ -91,24 +90,26 @@ const AnalysisView = ({
             title={`카테고리별 ${config.label}`}
             icon={<PieChart className={config.color} />}
           >
-            {/* 카테고리 차트 */}
-            <div className="flex items-center justify-center p-4">
-              <CategoryChart
-                data={categoryData}
-                selectedIndex={selectedIndex}
-                onSelect={setSelectedIndex}
-              />
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              {/* 카테고리 차트 */}
+              <div className="flex items-center justify-center lg:flex-1">
+                <CategoryChart
+                  data={categoryData}
+                  selectedIndex={selectedIndex}
+                  onSelect={setSelectedIndex}
+                />
+              </div>
+
+              <div className="lg:flex-1">
+                {/* 카테고리 리스트 */}
+                <CategoryAnalysisList
+                  data={categoryData}
+                  allTransactions={current}
+                  selectedIndex={selectedIndex}
+                  onSelect={setSelectedIndex}
+                />
+              </div>
             </div>
-
-            <Separator />
-
-            {/* 카테고리 리스트 */}
-            <CategoryAnalysisList
-              data={categoryData}
-              allTransactions={current}
-              selectedIndex={selectedIndex}
-              onSelect={setSelectedIndex}
-            />
           </AnalysisSection>
         </>
       )}

--- a/fe/src/components/analysis/AnalysisView.tsx
+++ b/fe/src/components/analysis/AnalysisView.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { AnalysisData, TransactionType } from '@/types/analysis';
-import { Info, PieChart } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { getMonthRange, getWeeksInMonth } from '@/utils/date';
+import { useEffect, useMemo, useState } from 'react';
 
 import { ANALYSIS_CONFIG } from '@/constants/analysis';
 import AnalysisEmpty from '@/components/analysis/common/AnalysisEmpty';
@@ -11,9 +11,10 @@ import { Button } from '@/components/ui/button';
 import CategoryAnalysisList from '@/components/analysis/CategoryAnalysisList';
 import CategoryChart from '@/components/analysis/CategoryChart';
 import Link from 'next/link';
+import { PieChart } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import WeeklyChart from '@/components/analysis/WeeklyChart';
-import { getMonthRange } from '@/utils/date';
+import WeeklyListCard from '@/components/analysis/WeeklyListCard';
 
 type AnalysisViewProps = {
   type: TransactionType;
@@ -32,11 +33,39 @@ const AnalysisView = ({
   const { current, prev, totalAmount, diff, categoryData } = initialData;
 
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
-  // 사용자가 달을 옮기면 '가장 많이 쓴 카테고리'부터 보여줌
+  const [selectedWeekIndex, setSelectedWeekIndex] = useState<number>(0);
+
+  // 주차별 데이터 가공
+  const weeklyData = useMemo(() => {
+    const weeks = getWeeksInMonth(selectedDate);
+
+    return weeks.map((week) => {
+      const weekTransactions = current.filter(
+        (t) => t.date >= week.startDate && t.date <= week.endDate
+      );
+      const totalAmount = weekTransactions.reduce(
+        (sum, t) => sum + t.amount,
+        0
+      );
+
+      return {
+        label: `${week.weekNumber}주차`,
+        period: `${week.startDate} ~ ${week.endDate}`,
+        amount: totalAmount,
+        transactions: weekTransactions.sort((a, b) =>
+          a.date.localeCompare(b.date)
+        ),
+      };
+    });
+  }, [current, selectedDate]);
+
+  // 현재 선택된 주차의 상세 데이터
+  const selectedWeekDetail = weeklyData[selectedWeekIndex];
+
+  // 달이 바뀌면 선택 인덱스 초기화
   useEffect(() => {
-    if (categoryData && categoryData.length > 0) {
-      setSelectedIndex(0);
-    }
+    if (categoryData && categoryData.length > 0) setSelectedIndex(0);
+    setSelectedWeekIndex(0);
   }, [selectedDate]);
 
   // 선택된 월 기준으로 history 페이지 이동용 URL 생성
@@ -94,10 +123,21 @@ const AnalysisView = ({
               <p className="font-semibold md:text-lg">주간 {config.label}</p>
 
               <WeeklyChart
-                transactions={current}
-                selectedDate={selectedDate}
+                data={weeklyData}
                 type={type}
+                selectedIndex={selectedWeekIndex}
+                onSelect={setSelectedWeekIndex}
               />
+
+              {/* 주간 상세 */}
+              {selectedWeekIndex !== -1 && selectedWeekDetail && (
+                <div className="mt-4">
+                  <WeeklyListCard
+                    index={selectedWeekIndex}
+                    detail={selectedWeekDetail}
+                  />
+                </div>
+              )}
             </div>
           </AnalysisSection>
 

--- a/fe/src/components/analysis/CategoryAnalysisList.tsx
+++ b/fe/src/components/analysis/CategoryAnalysisList.tsx
@@ -36,7 +36,7 @@ const CategoryAnalysisList = ({
         const index = Number(value.replace('item-', ''));
         if (!isNaN(index)) onSelect(index);
       }}
-      className="space-y-2 px-2 pt-6"
+      className="space-y-2 px-2"
     >
       {data.map((item, i) => {
         const isSelected = i === selectedIndex;

--- a/fe/src/components/analysis/CategoryChart.tsx
+++ b/fe/src/components/analysis/CategoryChart.tsx
@@ -44,12 +44,18 @@ const CategoryChart = ({
         hoverBackgroundColor: data.map((_, i) =>
           i < 5 ? CHART_COLORS.TOP_5[i] : CHART_COLORS.GRAY.LIGHT
         ),
-        borderWidth: data.map((_, i) => (i === selectedIndex ? 2 : 1)),
+        borderWidth:
+          data.length === 1
+            ? 0
+            : data.map((_, i) => (i === selectedIndex ? 0 : 1)),
         borderColor: isDark
           ? CHART_COLORS.BORDER.DARK
           : CHART_COLORS.BORDER.LIGHT,
-        offset: data.map((_, i) => (i === selectedIndex ? 25 : 0)), // 선택된 인덱스만 튀어나오도록
-        hoverOffset: 15, // 마우스 올렸을 때 튀어나오는 효과
+        offset:
+          data.length === 1
+            ? 0
+            : data.map((_, i) => (i === selectedIndex ? 20 : 0)), // 선택된 인덱스만 튀어나오도록
+        hoverOffset: data.length === 1 ? 0 : 15, // 마우스 올렸을 때 튀어나오는 효과
       },
     ],
   };

--- a/fe/src/components/analysis/CategoryChart.tsx
+++ b/fe/src/components/analysis/CategoryChart.tsx
@@ -85,14 +85,16 @@ const CategoryChart = ({
   const selectedItem = data[selectedIndex] || data[0];
 
   return (
-    <div className="relative mx-auto flex items-center justify-center">
+    <div className="relative mx-auto flex h-[250px] items-center justify-center md:h-[300px]">
       <Doughnut data={chartData} options={options} />
 
       <div className="pointer-events-none absolute flex flex-col items-center justify-center text-center">
         {selectedItem ? (
           <>
-            <span className="text-base font-semibold">{selectedItem.name}</span>
-            <span className="text-brand animate-in zoom-in text-xl font-bold duration-300">
+            <span className="text-sm font-semibold md:text-base">
+              {selectedItem.name}
+            </span>
+            <span className="text-brand animate-in zoom-in font-bold duration-300 md:text-lg">
               {selectedItem.percentage.toFixed(1)}%
             </span>
           </>

--- a/fe/src/components/analysis/WeeklyChart.tsx
+++ b/fe/src/components/analysis/WeeklyChart.tsx
@@ -14,8 +14,6 @@ import {
 import { CHART_COLORS } from '@/constants/colors';
 import { Line } from 'react-chartjs-2';
 import { TransactionAnalysis } from '@/types/analysis';
-import { getWeeksInMonth } from '@/utils/date';
-import { useMemo } from 'react';
 import { useTheme } from 'next-themes';
 
 // Line Chart에 필요한 요소 등록
@@ -28,36 +26,28 @@ ChartJS.register(
   Filler
 );
 
-type WeeklyChartProps = {
+type WeeklyData = {
+  label: string;
+  period: string;
+  amount: number;
   transactions: TransactionAnalysis[];
-  selectedDate: Date;
+};
+
+type WeeklyChartProps = {
+  data: WeeklyData[];
   type: string;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
 };
 
 const WeeklyChart = ({
-  transactions,
-  selectedDate,
+  data,
   type,
+  selectedIndex,
+  onSelect,
 }: WeeklyChartProps) => {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
-
-  // 주차별 데이터 가공
-  const weeklyData = useMemo(() => {
-    const weeks = getWeeksInMonth(selectedDate);
-
-    return weeks.map((week) => {
-      const totalAmount = transactions
-        .filter((t) => t.date >= week.startDate && t.date <= week.endDate)
-        .reduce((sum, t) => sum + t.amount, 0);
-
-      return {
-        label: `${week.weekNumber}주차`,
-        period: `${week.startDate} ~ ${week.endDate}`,
-        amount: totalAmount,
-      };
-    });
-  }, [transactions, selectedDate]);
 
   // 차트 색상
   const lineColor =
@@ -67,20 +57,21 @@ const WeeklyChart = ({
 
   // 차트 데이터 구성
   const chartData = {
-    labels: weeklyData.map((d) => d.label),
+    labels: data.map((d) => d.label),
     datasets: [
       {
         label: '금액',
-        data: weeklyData.map((d) => d.amount),
+        data: data.map((d) => d.amount),
         borderColor: lineColor, // 선 색상
         backgroundColor: fillColor, // 채워지는 영역 색상
         fill: true, // 영역 채우기 활성화
         tension: 0.4, // 곡선
-        pointRadius: 5, // 점 크기
         pointBackgroundColor: lineColor, // 점 색상
-        pointBorderWidth: 2,
+        pointBorderWidth: 1,
         pointBorderColor: '#fff', // 점 테두리
         borderWidth: 2, // 선 두께
+        pointRadius: data.map((_, i) => (i === selectedIndex ? 6 : 4)),
+        pointHoverRadius: 6,
       },
     ],
   };
@@ -98,7 +89,7 @@ const WeeklyChart = ({
         callbacks: {
           title: (tooltipItems) => {
             const index = tooltipItems[0].dataIndex;
-            return `${weeklyData[index].label} (${weeklyData[index].period})`;
+            return `${data[index].label} (${data[index].period})`;
           },
           label: (context) => ` ${context.raw?.toLocaleString()}원`,
         },
@@ -130,6 +121,18 @@ const WeeklyChart = ({
         },
         beginAtZero: true,
       },
+    },
+    onClick: (event, elements) => {
+      if (elements.length > 0) {
+        const index = elements[0].index;
+        onSelect(index);
+      }
+    },
+    onHover: (event, chartElement) => {
+      if (event.native) {
+        const target = event.native.target as HTMLElement;
+        target.style.cursor = chartElement.length ? 'pointer' : 'default';
+      }
     },
   };
 

--- a/fe/src/components/analysis/WeeklyChart.tsx
+++ b/fe/src/components/analysis/WeeklyChart.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  ChartOptions,
+  Filler,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from 'chart.js';
+
+import { CHART_COLORS } from '@/constants/colors';
+import { Line } from 'react-chartjs-2';
+import { TransactionAnalysis } from '@/types/analysis';
+import { getWeeksInMonth } from '@/utils/date';
+import { useMemo } from 'react';
+import { useTheme } from 'next-themes';
+
+// Line Chart에 필요한 요소 등록
+ChartJS.register(
+  CategoryScale, // x
+  LinearScale, // y
+  PointElement,
+  LineElement,
+  Tooltip,
+  Filler
+);
+
+type WeeklyChartProps = {
+  transactions: TransactionAnalysis[];
+  selectedDate: Date;
+  type: string;
+};
+
+const WeeklyChart = ({
+  transactions,
+  selectedDate,
+  type,
+}: WeeklyChartProps) => {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  // 주차별 데이터 가공
+  const weeklyData = useMemo(() => {
+    const weeks = getWeeksInMonth(selectedDate);
+
+    return weeks.map((week) => {
+      const totalAmount = transactions
+        .filter((t) => t.date >= week.startDate && t.date <= week.endDate)
+        .reduce((sum, t) => sum + t.amount, 0);
+
+      return {
+        label: `${week.weekNumber}주차`,
+        period: `${week.startDate} ~ ${week.endDate}`,
+        amount: totalAmount,
+      };
+    });
+  }, [transactions, selectedDate]);
+
+  // 차트 색상
+  const lineColor =
+    type === 'expense' ? 'rgb(255, 100, 103)' : 'rgb(81, 162, 255)';
+  const fillColor =
+    type === 'expense' ? 'rgba(255, 100, 103, 0.3)' : 'rgba(81, 162, 255, 0.3)';
+
+  // 차트 데이터 구성
+  const chartData = {
+    labels: weeklyData.map((d) => d.label),
+    datasets: [
+      {
+        label: '금액',
+        data: weeklyData.map((d) => d.amount),
+        borderColor: lineColor, // 선 색상
+        backgroundColor: fillColor, // 채워지는 영역 색상
+        fill: true, // 영역 채우기 활성화
+        tension: 0.4, // 곡선
+        pointRadius: 5, // 점 크기
+        pointBackgroundColor: lineColor, // 점 색상
+        pointBorderWidth: 2,
+        pointBorderColor: '#fff', // 점 테두리
+        borderWidth: 2, // 선 두께
+      },
+    ],
+  };
+
+  // 차트 옵션 설정
+  const options: ChartOptions<'line'> = {
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'index', // 마우스 올렸을 때 같은 X축 데이터 강조
+      intersect: false,
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          title: (tooltipItems) => {
+            const index = tooltipItems[0].dataIndex;
+            return `${weeklyData[index].label} (${weeklyData[index].period})`;
+          },
+          label: (context) => ` ${context.raw?.toLocaleString()}원`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: {
+          color: isDark ? '#A1A1AA' : '#52525B',
+          font: { size: 12 },
+        },
+        title: {
+          display: true,
+          text: '주차별 합계 (월요일~일요일 기준)',
+          color: isDark ? CHART_COLORS.GRAY.LIGHT : CHART_COLORS.GRAY.DARK,
+          font: { size: 12 },
+          padding: { top: 4 },
+        },
+      },
+      y: {
+        grid: {
+          color: isDark ? '#3b3b3b' : '#dfdfdf',
+        },
+        ticks: {
+          maxTicksLimit: 6,
+          color: isDark ? '#A1A1AA' : '#52525B',
+          font: { size: 12 },
+        },
+        beginAtZero: true,
+      },
+    },
+  };
+
+  return (
+    <div className="relative h-[250px] w-full md:h-[300px]">
+      <Line data={chartData} options={options} />
+    </div>
+  );
+};
+
+export default WeeklyChart;

--- a/fe/src/components/analysis/WeeklyListCard.tsx
+++ b/fe/src/components/analysis/WeeklyListCard.tsx
@@ -15,6 +15,7 @@ type WeeklyListCardProps = {
     period: string;
     amount: number;
     transactions: TransactionAnalysis[];
+    isCurrentWeek: boolean;
   };
 };
 
@@ -24,12 +25,23 @@ const WeeklyListCard = ({ index, detail }: WeeklyListCardProps) => {
       {/* 요약 헤더 */}
       <div className="flex w-full items-center justify-between gap-2 p-4">
         <div className="pl-2">
-          <div className="font-bold">{detail.label}</div>
+          <div className="flex items-center gap-2">
+            <span className="text-base font-bold tracking-tight">
+              {detail.label}
+            </span>
+
+            {detail.isCurrentWeek && (
+              <div className="bg-brand/10 text-brand ring-brand/20 items-center rounded-full px-2 py-0.5 text-xs font-bold ring-1 ring-inset">
+                이번 주
+              </div>
+            )}
+          </div>
+
           <span className="text-muted-foreground text-xs">
             ({detail.period})
           </span>
         </div>
-        <div className="text-sm font-semibold md:text-base">
+        <div className="shrink-0 text-sm font-semibold md:text-base">
           {detail.amount.toLocaleString()}원
         </div>
       </div>

--- a/fe/src/components/analysis/WeeklyListCard.tsx
+++ b/fe/src/components/analysis/WeeklyListCard.tsx
@@ -1,0 +1,82 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+
+import { Card } from '@/components/ui/card';
+import { TransactionAnalysis } from '@/types/analysis';
+
+type WeeklyListCardProps = {
+  index: number;
+  detail: {
+    label: string;
+    period: string;
+    amount: number;
+    transactions: TransactionAnalysis[];
+  };
+};
+
+const WeeklyListCard = ({ index, detail }: WeeklyListCardProps) => {
+  return (
+    <Card className="gap-0 overflow-hidden p-0">
+      {/* 요약 헤더 */}
+      <div className="flex w-full items-center justify-between gap-2 p-4">
+        <div className="pl-2">
+          <div className="font-bold">{detail.label}</div>
+          <span className="text-muted-foreground text-xs">
+            ({detail.period})
+          </span>
+        </div>
+        <div className="text-sm font-semibold md:text-base">
+          {detail.amount.toLocaleString()}원
+        </div>
+      </div>
+
+      {/* 토글 상세 내역 */}
+      <Accordion
+        type="single"
+        collapsible
+        key={index}
+        defaultValue="detail"
+        className="w-full"
+      >
+        <AccordionItem value="detail" className="border-none">
+          <AccordionTrigger className="bg-brand-subtle dark:bg-brand/10 cursor-pointer p-4 shadow-sm">
+            상세 거래 내역
+          </AccordionTrigger>
+
+          <AccordionContent className="p-0">
+            <div className="bg-brand-neutral/15 space-y-3 divide-y rounded-b-xl px-3 py-1 md:px-6 md:py-2">
+              {detail.transactions.length > 0 ? (
+                detail.transactions.map((t) => (
+                  <div
+                    key={t.id}
+                    className="flex items-center justify-between gap-2 py-2 text-xs tracking-tight break-keep md:text-sm"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="text-muted-foreground text-[10px] md:text-xs">
+                        {t.category?.name_ko}
+                      </span>
+                      <span className="font-semibold">{t.title}</span>
+                    </div>
+                    <span className="font-semibold">
+                      {t.amount.toLocaleString()}원
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-muted-foreground py-2 text-center text-xs">
+                  이 기간에는 거래 내역이 없어요.
+                </p>
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </Card>
+  );
+};
+
+export default WeeklyListCard;

--- a/fe/src/utils/date.ts
+++ b/fe/src/utils/date.ts
@@ -1,4 +1,10 @@
-import { startOfWeek, endOfWeek } from 'date-fns';
+import {
+  eachWeekOfInterval,
+  endOfMonth,
+  endOfWeek,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
 
 /** 선택된 날짜를 바탕으로 해당 월의 시작일과 종료일을 YYYY-MM-DD 형식으로 반환 */
 export const getMonthRange = (date: Date) => {
@@ -24,6 +30,31 @@ export const getWeekRange = (date: Date) => {
     startDate: formatLocalDate(start),
     endDate: formatLocalDate(end),
   };
+};
+
+// 해당 월의 모든 주차 범위
+export const getWeeksInMonth = (date: Date) => {
+  const monthStart = startOfMonth(date);
+  const monthEnd = endOfMonth(date);
+
+  // 해당 월의 모든 월요일(주 시작점) 가져옴
+  const weekStarts = eachWeekOfInterval(
+    { start: monthStart, end: monthEnd },
+    { weekStartsOn: 1 }
+  );
+
+  return weekStarts.map((weekStart, index) => {
+    const weekEnd = endOfWeek(weekStart, { weekStartsOn: 1 });
+
+    // 월 범위를 벗어나지 않도록 날짜 조정
+    return {
+      weekNumber: index + 1,
+      startDate: formatLocalDate(
+        weekStart < monthStart ? monthStart : weekStart
+      ),
+      endDate: formatLocalDate(weekEnd > monthEnd ? monthEnd : weekEnd),
+    };
+  });
 };
 
 // Date 객체를 'YYYY-MM-DD' 문자열로 변환


### PR DESCRIPTION
## PR 개요
- 단일 카테고리(100%) 데이터에서 발생하던 도넛 차트 UI 깨짐 문제를 수정했습니다.
- 주간 단위 지출/수입 추이를 라인 차트로 제공하여 사용자가 한 달 내 소비 흐름을 직관적으로 파악할 수 있도록 했습니다.

## 변경 사항
### 1. 도넛 차트 개선
- 도넛 차트가 100% 비율일 때 테두리 틈새가 발생하던 문제 수정
  - `data.length === 1`인 경우 `borderWidth`, `offset`을 `0`으로 설정
- 카테고리 분석 섹션 반응형 레이아웃 적용
  - `lg` 이상 화면에서 세로(column) → 가로(row) 배치로 변경

### 2. 주간 단위 차트 추가
- 월별 주차 범위 계산 유틸리티 함수 `getWeeksInMonth` 추가
    - 특정 월의 **주차별 시작/종료일 범위 반환 (월요일 시작 기준)**
- 주간 지출/수입 추이 **라인 차트(`WeeklyChart`)** 구현
    - 월요일 기준 주차별 합계 로직 적용
- 주간 수입/지출 상세 리스트 및 차트 연동
    - 주간 상세 내역을 보여주는 `WeeklyListCard` 구현
    - 주차별 데이터 가공 로직을 `AnalysisView`로 이동
    - 차트 선택 시 리스트 동기화 및 아코디언 자동 펼침 처리
- 월 이동 UX 개선
    - 현재 달: **오늘이 포함된 주차 자동 선택**
    - 그 외의 달: **1주차 자동 선택**
- 현재 주차 리스트에 **‘이번 주’ 배지 표시**

## 스크린샷 (선택)
### 카테고리 도넛 차트 (desktop)
| Before | After |
|------------|------------|
| <img width="1233" height="918" alt="image" src="https://github.com/user-attachments/assets/53f479bb-2c4b-4178-840c-024536607a77" /> | <img width="1231" height="642" alt="image" src="https://github.com/user-attachments/assets/0a4c924f-e0a3-45c7-aa3e-593d2743e28a" /> |

### 주간 라인 차트
| Before | After |
|------------|------------|
| <img width="800" height="279" alt="image" src="https://github.com/user-attachments/assets/e64791ce-678f-4da0-b90f-96c3ba80633d" /> | ![WeeklyChart](https://github.com/user-attachments/assets/d0354974-0b9a-4b1a-9e5d-7862a481ff0a) |

## 리뷰 요청 사항
- 아래 내용 확인 부탁드립니다.
  - 월요일 기준으로 주차 구분해서 표시했는데, 제대로 금액이 뜨는지
  - 현재 달에서 오늘이 포함된 주차로 선택이 되는지 ('이번 주' 뱃지 표시 여부)
  - 도넛 차트가 100% 비율일 때, 틈새가 없는지


## 추후 할 일
- [ ] 미래 날짜 거래 내역이 분석 페이지에서 누락되는 문제 수정