### PR TITLE
[fix] 미래 날짜 거래 내역이 분석 페이지에서 누락되는 문제

### DIFF
--- a/fe/src/services/analysis/analysisService.server.ts
+++ b/fe/src/services/analysis/analysisService.server.ts
@@ -44,7 +44,7 @@ export const getAnalysisData = async (
 
     // 고정비 동기화
     const today = formatLocalDate(new Date());
-    const queryEndDate = endDate > today ? today : endDate;
+
     await Promise.all([
       // 지난 달: 전체 기간 동기화
       safeSyncServer({
@@ -74,7 +74,7 @@ export const getAnalysisData = async (
       .eq('user_id', userId)
       .eq('type', type)
       .gte('date', prevStart)
-      .lte('date', queryEndDate)
+      .lte('date', endDate)
       .order('date', { ascending: false });
 
     if (error) throw error;
@@ -83,11 +83,10 @@ export const getAnalysisData = async (
 
     // 이번 달과 지난 달 데이터 분리
     const current = normalized.filter(
-      (t) => t.date >= startDate && t.date <= queryEndDate
+      (t) => t.date >= startDate && t.date <= endDate
     );
     const prev = normalized.filter(
-      (t) =>
-        t.date >= prevStart && t.date <= (prevEnd > today ? today : prevEnd)
+      (t) => t.date >= prevStart && t.date <= prevEnd
     );
 
     return {


### PR DESCRIPTION
## PR 개요
- 분석 데이터 조회 시 미래 날짜의 거래 내역이 누락되는 현상 수정

## 변경 사항
- `getAnalysisData` 내에서 조회 종료 시점을 오늘(`today`)로 제한하던 `queryEndDate` 변수를 제거하고, 선택된 월의 마지막 날(`endDate`)까지 데이터를 가져오도록 수정
- `current` (이번 달) 데이터 필터링 시 `endDate`를 사용하여 미래에 등록된 수동 거래 내역이 포함되도록 수정
- `prev` (지난달) 데이터 필터링 시에도 `prevEnd` 전체 범위를 사용하도록 수정

## 스크린샷 (선택)
### 미래 거래 내역 생성 (TEST용)
> 오늘 날짜: 1월 28일

| 이번 달 미래 거래 생성(1/30) | 다음 달 미래 거래 생성(2/4) |
|------------|------------|
| <img width="1884" height="1460" alt="image" src="https://github.com/user-attachments/assets/0abe2c4e-3533-4ad9-b921-fe32e40f52f8" /> | <img width="1889" height="1468" alt="image" src="https://github.com/user-attachments/assets/765e078c-c8a0-491a-88f1-8d502083ba90" /> |
| 총 지출 336,060원 | 총 지출 100,000원 |

### 분석 페이지
| Before (이번 달 확인) | After (이번 달 확인) |
|------------|------------|
| <img width="1892" height="2028" alt="image" src="https://github.com/user-attachments/assets/f6a2bf1a-54c9-4e51-ab2b-2a0231fdcef8" /> | <img width="1892" height="2226" alt="image" src="https://github.com/user-attachments/assets/97bfc7cc-34fc-42bd-a896-dbf926b72488" /> |
| 총 지출 금액 차이와 경조 카테고리 없음 | 총 지출 금액과 경조 카테고리 확인 |

| Before (다음 달 확인) | After (다음 달 확인) |
|------------|------------|
| <img width="1892" height="1660" alt="image" src="https://github.com/user-attachments/assets/8074c200-fdae-4503-8f18-985b3b9bd211" /> | <img width="1892" height="1722" alt="image" src="https://github.com/user-attachments/assets/f4c74fca-e09a-40ca-a766-7533bd95ec33" /> |


## 리뷰 요청 사항
- 아래 내용 확인 부탁드립니다.
  - 미래 날짜 거래 생성 시, 분석 페이지에 반영이 되는지
  - 고정비 규칙 생성 후, 분석 페이지에서 미래 달로 이동했을 때 실제 고정비 거래 내역이 생성되지 않는지

## 추후 할 일
- [ ] 달 전환 시 사용자가 원하는 달을 선택할 수 있게 개선