### PR TITLE
[refactor] middleware 프로필 DB 조회 제거 및 온보딩 상태 쿠키 캐싱

### DIFF
--- a/fe/src/app/(auth)/auth/callback/route.ts
+++ b/fe/src/app/(auth)/auth/callback/route.ts
@@ -34,25 +34,36 @@ export async function GET(request: Request) {
     return NextResponse.redirect(`${origin}/login`);
   }
 
-  // 유저 프로필 존재 여부 조회
+  // 유저 프로필 존재 여부 조회 (로그인 직후 1회만)
   const { data: profile } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', user.id)
     .maybeSingle();
 
-  const nextPath = profile ? next : '/onboarding';
+  const onboarded = !!profile;
+  const nextPath = onboarded ? next : '/onboarding';
 
   const forwardedHost = request.headers.get('x-forwarded-host'); // original origin before load balancer
   const isLocalEnv = process.env.NODE_ENV === 'development';
 
+  let redirectUrl: string;
   if (isLocalEnv) {
     // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-    return NextResponse.redirect(`${origin}${nextPath}`);
+    redirectUrl = `${origin}${nextPath}`;
+  } else if (forwardedHost) {
+    redirectUrl = `https://${forwardedHost}${nextPath}`;
+  } else {
+    redirectUrl = `${origin}${nextPath}`;
   }
 
-  if (forwardedHost) {
-    return NextResponse.redirect(`https://${forwardedHost}${nextPath}`);
-  }
-  return NextResponse.redirect(`${origin}${nextPath}`);
+  const response = NextResponse.redirect(redirectUrl);
+  response.cookies.set('onboarded', onboarded ? '1' : '0', {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: !isLocalEnv,
+  });
+
+  return response;
 }

--- a/fe/src/app/api/profile/route.ts
+++ b/fe/src/app/api/profile/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { onboardingProfileSchema, profilePatchSchema } from '@/schemas/profile';
+import { cookies } from 'next/headers';
 
 async function requireUser() {
   const supabase = await createClient();
@@ -111,7 +112,16 @@ export async function PUT(req: Request) {
     return NextResponse.json({ message: error.message }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true });
+  // 온보딩 완료 캐시 쿠키 갱신
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set('onboarded', '1', {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV !== 'development',
+  });
+
+  return res;
 }
 
 // MyInfo - 프로필 수정

--- a/fe/src/utils/supabase/middleware.ts
+++ b/fe/src/utils/supabase/middleware.ts
@@ -62,6 +62,10 @@ export async function updateSession(request: NextRequest) {
   const isOnboardingPath = pathname.startsWith('/onboarding');
   const isOnboardingIntroPath = pathname.startsWith('/onboarding/intro');
 
+  // 온보딩 완료 여부 판단 쿠키
+  const onboardedCookie = request.cookies.get('onboarded')?.value;
+  const isOnboarded = onboardedCookie === '1';
+
   // 비로그인 : login/auth만 허용
   if (!user) {
     if (!isLoginPath && !isAuthPath) {
@@ -73,31 +77,15 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
-  const userId = user.sub; // claims의 subject = auth uid(uuid)
-
-  // 로그인 : 프로필 존재 여부 조회
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('id', userId)
-    .maybeSingle();
-
-  if (profileError) {
-    console.error('[middleware] profile fetch error', profileError);
-    return supabaseResponse;
-  }
-
-  const hasProfile = !!profile;
-
-  // 로그인 상태에서 login 페이지 접근 차단
+  // 로그인 상태에서 /login 접근 차단
   if (isLoginPath) {
     const url = request.nextUrl.clone();
-    url.pathname = hasProfile ? '/' : '/onboarding';
+    url.pathname = isOnboarded ? '/' : '/onboarding';
     return NextResponse.redirect(url);
   }
 
-  // 온보딩 미완료면 onboarding만 허용
-  if (!hasProfile) {
+  // 온보딩 미완료면 /onboarding만 허용
+  if (!isOnboarded) {
     // /auth는 OAuth 플로우 때문에 허용
     if (!isOnboardingPath && !isAuthPath) {
       const url = request.nextUrl.clone();
@@ -107,7 +95,7 @@ export async function updateSession(request: NextRequest) {
     return supabaseResponse;
   }
 
-  // 온보딩 완료면 onboarding 접근 차단
+  // 온보딩 완료면 /onboarding 접근 차단
   if (isOnboardingPath && !isOnboardingIntroPath) {
     const url = request.nextUrl.clone();
     url.pathname = '/';


### PR DESCRIPTION
## PR 개요
로그인 필수 구조에서 middleware가 매 요청마다 `profiles` 테이블을 조회하던 구조를 개선했습니다.
온보딩 완료 여부를 DB가 아닌 커스텀 쿠키(`onboarded`)로 캐싱하여 판단하도록 변경해, 페이지 이동 시 불필요한 DB 쿼리를 제거했습니다.

## 변경 사항
### 1. OAuth 콜백에서 온보딩 상태 쿠키 세팅
- 로그인 직후 `/auth/callback`에서 프로필 존재 여부를 **1회만 조회**
- 결과에 따라 `onboarded=1/0` 쿠키를 세팅
- 이후 middleware는 DB 조회 없이 쿠키로 분기 가능
### 2. middleware에서 프로필 DB 조회 제거
- `profiles.select(...)` 로직 완전 제거
- `onboarded` 쿠키 기반으로 라우팅 가드 처리
    - 비로그인 → `/login`
    - 로그인 + 온보딩 미완료 → `/onboarding`
    - 로그인 + 온보딩 완료 → `/` (onboarding 접근 차단)
### 3. 온보딩 완료 시 쿠키 갱신
- 온보딩 PUT 성공 시 `onboarded=1` 쿠키 갱신
- 온보딩 완료 직후 소개/홈 이동 시 middleware 리다이렉트 충돌 방지

## 스크린샷
### 온보딩 상태 쿠키(onboarded) 설정
before | after
-- | --
<img width="978" height="288" alt="스크린샷 2026-01-28 13 26 56" src="https://github.com/user-attachments/assets/b391e984-0579-4f8b-b05d-c895d4c3f4ad" />| <img width="978" height="288" alt="스크린샷 2026-01-28 13 25 51" src="https://github.com/user-attachments/assets/bfa3f071-8307-4742-8bab-3ba6be23c34d" />
### DB 조회 횟수 비교
> Supabase Query Performance

before | after
-- | --
<img width="360" height="432" alt="스크린샷 2026-01-27 17 31 23" src="https://github.com/user-attachments/assets/d9f0f18a-7841-4cfa-a8d6-2405f9774b79" />| <img width="360" height="432" src="https://github.com/user-attachments/assets/5e06f75f-e114-4b72-80f7-bdc359ae1c95" />

## 리뷰 요청 사항
- 아래 케이스에서 **페이지 이동/리다이렉트가 정상 동작하는지** 확인 부탁드립니다.
    1. **비로그인 상태**에서 `/login` 외 경로 접근 → `/login`으로 리다이렉트
    2. **신규 로그인 유저(온보딩 미완료)** → `/onboarding`으로 이동
    3. **온보딩 완료 후** `/` 정상 진입
    4. **온보딩 완료 상태**에서 `/onboarding` 접근 → `/`로 리다이렉트
- 사용자가 프로필 정보 입력 전/후로 **쿠키 캐싱이 정상 동작하는지** Application 탭에서 확인 부탁드립니다.
    - 로그인 직후(온보딩 미완료 사용자): `onboarded=0`
    - 기본 정보 입력 후(소개 페이지로 이동 시점): `onboarded=1`

## 추후 할 일
- [x] 로그인 페이지 개선 #136 