### PR TITLE
[refactor] 월 이동 방식 통일을 위한 월 선택 컴포넌트 공통화

### DIFF
--- a/fe/src/components/analysis/common/MonthNavigator.tsx
+++ b/fe/src/components/analysis/common/MonthNavigator.tsx
@@ -1,8 +1,7 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+'use client';
 
-import Link from 'next/link';
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import MonthPicker from '@/components/common/MonthPicker';
+import { useRouter } from 'next/navigation';
 
 type MonthNavigatorProps = {
   year: number;
@@ -11,44 +10,17 @@ type MonthNavigatorProps = {
 };
 
 const MonthNavigator = ({ year, month, baseUrl }: MonthNavigatorProps) => {
-  // 이전 달, 다음 달 계산 로직
-  const prevDate = new Date(year, month - 2);
-  const nextDate = new Date(year, month);
+  const router = useRouter();
 
-  const prevQuery = `?year=${prevDate.getFullYear()}&month=${prevDate.getMonth() + 1}`;
-  const nextQuery = `?year=${nextDate.getFullYear()}&month=${nextDate.getMonth() + 1}`;
+  const handleDateChange = (newYear: number, newMonth: number) => {
+    const queryString = `?year=${newYear}&month=${newMonth}`;
+
+    router.push(`${baseUrl}${queryString}`);
+  };
 
   return (
     <div className="flex flex-col items-center justify-center py-6 md:py-10">
-      <span className="text-brand font-bold">{year}</span>
-
-      <div className="flex items-center justify-center gap-3">
-        <Link
-          href={`${baseUrl}${prevQuery}`}
-          aria-label="이전 달"
-          className={cn(
-            buttonVariants({ variant: 'ghost', size: 'icon' }),
-            'hover:bg-brand/10'
-          )}
-          prefetch={false}
-        >
-          <ChevronLeft />
-        </Link>
-
-        <span className="text-2xl font-bold">{month}월</span>
-
-        <Link
-          href={`${baseUrl}${nextQuery}`}
-          aria-label="다음 달"
-          className={cn(
-            buttonVariants({ variant: 'ghost', size: 'icon' }),
-            'hover:bg-brand/10'
-          )}
-          prefetch={false}
-        >
-          <ChevronRight />
-        </Link>
-      </div>
+      <MonthPicker year={year} month={month} onDateChange={handleDateChange} />
     </div>
   );
 };

--- a/fe/src/components/calendar/CalendarCaption.tsx
+++ b/fe/src/components/calendar/CalendarCaption.tsx
@@ -43,7 +43,7 @@ export const CalendarCaption = ({
             onDateChange={(selectedYear, selectedMonth) => {
               // 연도가 바뀌었을 때
               if (selectedYear !== year) {
-                const newDate = new Date(selectedYear, month.getMonth(), 1);
+                const newDate = new Date(selectedYear, selectedMonth - 1, 1);
                 handleMonthChange(newDate);
               }
               // 월이 바뀌었을 때

--- a/fe/src/components/calendar/CalendarCaption.tsx
+++ b/fe/src/components/calendar/CalendarCaption.tsx
@@ -1,18 +1,7 @@
 'use client';
-import { useState } from 'react';
-import { Button } from '../ui/button';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { cn } from '@/lib/utils';
 
-const MONTHS = Array.from({ length: 12 }, (_, i) => ({
-  month: i + 1,
-  monthDisplay: `${i + 1}월`,
-}));
+import MonthPicker from '../common/MonthPicker';
+import { cn } from '@/lib/utils';
 
 interface CalendarCaptionProps {
   year: number;
@@ -37,18 +26,6 @@ export const CalendarCaption = ({
   handleMonthChange,
   children,
 }: CalendarCaptionProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [mode, setMode] = useState<'month' | 'year'>('month');
-
-  const currentYear = new Date().getFullYear();
-  const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
-
-  const handleYearSelect = (selectedYear: number) => {
-    const newDate = new Date(selectedYear, month.getMonth(), 1);
-    handleMonthChange(newDate);
-    setMode('month');
-  };
-
   return (
     <div className="mb-4 w-full">
       <div className="flex flex-col-reverse gap-2 lg:flex-row">
@@ -60,84 +37,23 @@ export const CalendarCaption = ({
             'border-l-brand border-l-4'
           )}
         >
-          <div className="flex flex-col items-center">
-            <span className="text-muted-foreground text-xs">{year}</span>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-brand-soft/40 h-8 w-8"
-                onClick={() => moveMonth(-1)}
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
+          <MonthPicker
+            year={year}
+            month={displayMonth}
+            onDateChange={(selectedYear, selectedMonth) => {
+              // 연도가 바뀌었을 때
+              if (selectedYear !== year) {
+                const newDate = new Date(selectedYear, month.getMonth(), 1);
+                handleMonthChange(newDate);
+              }
+              // 월이 바뀌었을 때
+              else {
+                navigateMonth(selectedMonth);
+              }
+            }}
+            onMoveClick={moveMonth}
+          />
 
-              <Popover open={isOpen} onOpenChange={setIsOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className={cn(
-                      'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
-                      'text-xl tracking-tight sm:text-2xl'
-                    )}
-                  >
-                    {displayMonth}월
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  {mode === 'month' ? (
-                    <div className="grid grid-cols-3 p-2">
-                      <div
-                        onClick={() => setMode('year')}
-                        className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
-                      >
-                        {year}
-                      </div>
-                      {MONTHS.map(({ month, monthDisplay }) => (
-                        <div
-                          className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 rounded text-center text-xs"
-                          onClick={() => {
-                            navigateMonth(month);
-                            setIsOpen(false);
-                          }}
-                          key={month}
-                        >
-                          {monthDisplay}
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="grid grid-cols-3 p-2">
-                      <div
-                        className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
-                        onClick={() => setMode('month')}
-                      >
-                        {displayMonth}월
-                      </div>
-                      {years.map((y) => (
-                        <div
-                          key={y}
-                          className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer items-center justify-center rounded text-sm"
-                          onClick={() => handleYearSelect(y)}
-                        >
-                          {y}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </PopoverContent>
-              </Popover>
-
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-brand-soft/40 h-8 w-8"
-                onClick={() => moveMonth(1)}
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
           <div className="space-y-1 text-right">
             <div className="flex items-baseline justify-end gap-2">
               <span className="text-muted-foreground text-xs font-medium sm:text-sm">

--- a/fe/src/components/common/MonthPicker.tsx
+++ b/fe/src/components/common/MonthPicker.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+
+import { Button } from '../ui/button';
+import { cn } from '@/lib/utils';
+import { useState } from 'react';
+
+const MONTHS = Array.from({ length: 12 }, (_, i) => ({
+  month: i + 1,
+  monthDisplay: `${i + 1}월`,
+}));
+
+interface MonthPickerProps {
+  year: number;
+  month: number;
+  onDateChange: (year: number, month: number) => void; // 날짜 변경 시
+  onMoveClick?: (delta: number) => void; // 화살표 이동 시
+  className?: string;
+}
+
+const MonthPicker = ({
+  year,
+  month,
+  onDateChange,
+  onMoveClick,
+}: MonthPickerProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<'month' | 'year'>('month');
+
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
+
+  // 연도 선택 핸들러
+  const handleYearSelect = (selectedYear: number) => {
+    onDateChange(selectedYear, month);
+    setMode('month'); // 연도 선택 후 월 선택 모드로 돌아가기
+  };
+
+  // 월 선택 핸들러
+  const handleMonthSelect = (selectedMonth: number) => {
+    onDateChange(year, selectedMonth);
+    setIsOpen(false); // 팝오버 닫기
+  };
+
+  // 화살표 이동 핸들러
+  const handleMove = (delta: number) => {
+    if (onMoveClick) {
+      // 전용 함수가 있으면 사용
+      onMoveClick(delta);
+    } else {
+      // 없으면 직접 계산해서 onDateChange 호출
+      const targetDate = new Date(year, month - 1 + delta, 1);
+      onDateChange(targetDate.getFullYear(), targetDate.getMonth() + 1);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <span className="text-brand text-sm font-bold">{year}</span>
+      <div className="flex items-center gap-2">
+        {/* 이전 달 이동 버튼 */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hover:bg-brand-soft/40 h-8 w-8"
+          onClick={() => handleMove(-1)}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+
+        {/* 연/월 선택 */}
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              className={cn(
+                'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
+                'text-xl tracking-tight sm:text-2xl'
+              )}
+            >
+              {month}월
+            </Button>
+          </PopoverTrigger>
+
+          <PopoverContent className="w-auto p-0" align="start">
+            {mode === 'month' ? (
+              <div className="grid grid-cols-3 p-2">
+                <div
+                  onClick={() => setMode('year')}
+                  className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
+                >
+                  {year}
+                </div>
+
+                {MONTHS.map(({ month, monthDisplay }) => (
+                  <div
+                    className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer flex-col items-center justify-center gap-2 rounded text-center text-xs"
+                    onClick={() => handleMonthSelect(month)}
+                    key={month}
+                  >
+                    {monthDisplay}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 p-2">
+                <div
+                  className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
+                  onClick={() => setMode('month')}
+                >
+                  {month}월
+                </div>
+                {years.map((y) => (
+                  <div
+                    key={y}
+                    className="hover:bg-accent hover:text-accent-foreground flex h-12 w-12 cursor-pointer items-center justify-center rounded text-sm"
+                    onClick={() => handleYearSelect(y)}
+                  >
+                    {y}
+                  </div>
+                ))}
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+
+        {/* 다음 달 이동 버튼 */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hover:bg-brand-soft/40 h-8 w-8"
+          onClick={() => handleMove(1)}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default MonthPicker;

--- a/fe/src/components/common/MonthPicker.tsx
+++ b/fe/src/components/common/MonthPicker.tsx
@@ -66,7 +66,8 @@ const MonthPicker = ({
 
   return (
     <div className="flex flex-col items-center">
-      <span className="text-brand text-sm font-bold">{year}</span>
+      <span className="text-brand text-sm font-bold md:text-base">{year}</span>
+
       <div className="flex items-center gap-2">
         {/* 이전 달 이동 버튼 */}
         <Button
@@ -85,7 +86,7 @@ const MonthPicker = ({
               variant="ghost"
               className={cn(
                 'hover:bg-brand-soft/40 w-16 justify-center font-semibold',
-                'text-xl tracking-tight sm:text-2xl'
+                'text-lg tracking-tight md:text-xl'
               )}
             >
               {month}월

--- a/fe/src/components/common/MonthPicker.tsx
+++ b/fe/src/components/common/MonthPicker.tsx
@@ -2,10 +2,10 @@
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { useEffect, useState } from 'react';
 
 import { Button } from '../ui/button';
 import { cn } from '@/lib/utils';
-import { useState } from 'react';
 
 const MONTHS = Array.from({ length: 12 }, (_, i) => ({
   month: i + 1,
@@ -28,19 +28,27 @@ const MonthPicker = ({
 }: MonthPickerProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<'month' | 'year'>('month');
+  const [tempYear, setTempYear] = useState(year); // 임시 연도 상태
+
+  useEffect(() => {
+    if (isOpen) {
+      setTempYear(year);
+      setMode('month'); // 월 선택 모드
+    }
+  }, [isOpen, year]);
 
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: 10 }, (_, i) => currentYear - 5 + i);
 
   // 연도 선택 핸들러
   const handleYearSelect = (selectedYear: number) => {
-    onDateChange(selectedYear, month);
+    setTempYear(selectedYear);
     setMode('month'); // 연도 선택 후 월 선택 모드로 돌아가기
   };
 
   // 월 선택 핸들러
   const handleMonthSelect = (selectedMonth: number) => {
-    onDateChange(year, selectedMonth);
+    onDateChange(tempYear, selectedMonth);
     setIsOpen(false); // 팝오버 닫기
   };
 
@@ -91,7 +99,7 @@ const MonthPicker = ({
                   onClick={() => setMode('year')}
                   className="hover:bg-accent hover:text-accent-foreground col-span-3 cursor-pointer rounded p-2 text-center font-bold"
                 >
-                  {year}
+                  {tempYear}
                 </div>
 
                 {MONTHS.map(({ month, monthDisplay }) => (


### PR DESCRIPTION
## PR 개요
- 월 단위 데이터를 사용하는 여러 페이지에서 월 이동 방식이 서로 달라 UX가 일관되지 않는 문제를 해결하기 위해, 연도/월 선택 기능을 포함한 공통 컴포넌트 `MonthPicker`를 분리하고 각 페이지에 적용했습니다.

## 변경 사항
- 연도 및 월 선택 기능이 포함된 공통 컴포넌트 `MonthPicker` 생성
- 홈, 분석/예산 페이지에 `MonthPicker` 공통 컴포넌트 적용
- `MonthPicker` 연도/월 선택 흐름 개선
  - 연도 변경 시 즉시 데이터를 불러오지 않고 내부 상태(tempYear)만 변경
  - 월까지 최종 선택했을 때 연도/월 변경 사항이 반영되도록 수정
  - 연도 선택 시 발생하던 불필요한 API 요청 및 화면 깜빡임 방지
- 홈 화면에서 연도 변경 시 기존 월 데이터가 덮어씌워지던 문제 해결
  - `MonthPicker`로부터 전달받은 `selectedMonth`를 사용해 연도·월을 동시에 업데이트하도록 수정

## 스크린샷 (선택)
> 25년 11월로 이동하고자 함

| Before | After |
|------------|------------|
| ![MonthPicker_before](https://github.com/user-attachments/assets/20e35b91-fad0-4f99-baac-ccb68a997570) | ![MonthPicker_after](https://github.com/user-attachments/assets/55c7f745-3d0b-4215-92ee-875f58cfbc4e) |

## 리뷰 요청 사항
- 아래 내용 확인 부탁드립니다.
  - 분석 / 예산 페이지에서도 연도 및 월 선택 전환이 정상적으로 동작하는지
  - 연도 클릭 시 즉시 데이터가 변경되지 않고, 월까지 선택해야 데이터가 변경되는지
