### PR TITLE
[fix] onboarded 쿠키 유실 시 온보딩 리다이렉트 회귀 수정

### DIFF
--- a/fe/src/app/(auth)/auth/callback/route.ts
+++ b/fe/src/app/(auth)/auth/callback/route.ts
@@ -58,12 +58,18 @@ export async function GET(request: Request) {
   }
 
   const response = NextResponse.redirect(redirectUrl);
-  response.cookies.set('onboarded', onboarded ? '1' : '0', {
-    path: '/',
-    httpOnly: true,
-    sameSite: 'lax',
-    secure: !isLocalEnv,
-  });
+  if (onboarded) {
+    response.cookies.set('onboarded', '1', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: !isLocalEnv,
+      maxAge: 60 * 60 * 24 * 365,
+    });
+  } else {
+    // 미완료 시 쿠키 삭제
+    response.cookies.delete('onboarded');
+  }
 
   return response;
 }

--- a/fe/src/app/api/profile/route.ts
+++ b/fe/src/app/api/profile/route.ts
@@ -119,6 +119,7 @@ export async function PUT(req: Request) {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV !== 'development',
+    maxAge: 60 * 60 * 24 * 365, // 1년
   });
 
   return res;

--- a/fe/src/utils/supabase/middleware.ts
+++ b/fe/src/utils/supabase/middleware.ts
@@ -55,19 +55,20 @@ export async function updateSession(request: NextRequest) {
   // IMPORTANT: If you remove getClaims() and you use server-side rendering
   // with the Supabase client, your users may be randomly logged out.
   const { data } = await supabase.auth.getClaims();
-  const user = data?.claims;
+  const claims = data?.claims;
+  const userId = claims?.sub;
 
   const isAuthPath = pathname.startsWith('/auth');
   const isLoginPath = pathname.startsWith('/login');
   const isOnboardingPath = pathname.startsWith('/onboarding');
   const isOnboardingIntroPath = pathname.startsWith('/onboarding/intro');
 
-  // 온보딩 완료 여부 판단 쿠키
+  // 쿠키를 통해 온보딩 완료 여부 판단
   const onboardedCookie = request.cookies.get('onboarded')?.value;
-  const isOnboarded = onboardedCookie === '1';
+  let isOnboarded = onboardedCookie === '1';
 
   // 비로그인 : login/auth만 허용
-  if (!user) {
+  if (!userId) {
     if (!isLoginPath && !isAuthPath) {
       // no user, potentially respond by redirecting the user to the login page
       const url = request.nextUrl.clone();
@@ -75,6 +76,28 @@ export async function updateSession(request: NextRequest) {
       return NextResponse.redirect(url);
     }
     return supabaseResponse;
+  }
+
+  // 쿠키가 없으면 DB로 profiles 존재 확인
+  if (!isOnboarded) {
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (!error && profile) {
+      isOnboarded = true;
+
+      // 쿠키 재발급
+      supabaseResponse.cookies.set('onboarded', '1', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 60 * 60 * 24 * 365, // 1년
+      });
+    }
   }
 
   // 로그인 상태에서 /login 접근 차단


### PR DESCRIPTION
## PR 개요
온보딩 완료 사용자임에도 `onboarded` 쿠키 유실 시
로그인 상태에서 `/onboarding`으로 잘못 리다이렉트되던 회귀 이슈를 수정합니다.

기존에는 온보딩 완료 여부를 커스텀 쿠키만으로 판단했기 때문에,
브라우저 종료·쿠키 삭제·OAuth callback 타이밍 이슈 상황에서
완료 사용자가 미완료로 오판정되는 문제가 있었습니다.

이번 PR에서는 온보딩 완료 여부의 기준을 **DB(profiles 존재 여부)** 로 유지하면서,
쿠키는 성능 최적화를 위한 캐시로만 사용하도록 구조를 보완했습니다.

## 변경 사항
### 1. middleware fallback 로직 추가
- `onboarded` 쿠키가 없는 경우에만 `profiles` 테이블을 조회
- 프로필이 존재하면 온보딩 완료로 판단하고 `onboarded=1` 쿠키 재발급
- 평상시에는 쿠키 기반으로 판단하여 불필요한 DB 조회를 방지

### 2. OAuth callback 쿠키 정책 수정
- 온보딩 미완료 상태를 `onboarded=0`으로 저장하던 로직 제거
- 온보딩 완료 시에만 `onboarded=1` 쿠키 설정
- 미완료 상태에서는 쿠키를 설정하지 않거나 삭제하도록 변경

### 3. 온보딩 완료 쿠키 영속화
- 프로필 생성(온보딩 완료) 시 설정되는 `onboarded` 쿠키에 `maxAge` 추가
- 브라우저 종료 시 세션 쿠키가 만료되어 재리다이렉트가 발생하던 문제 방지

## 리뷰 요청 사항
> 다음과 같은 상황에서 의도한대로 동작하는지 확인 부탁드립니다.

- 온보딩 완료 사용자 상태에서 `onboarded` 쿠키 삭제 후 새로고침
  - `/onboarding`으로 이동하지 않고 정상 진입
- OAuth 로그인 직후 프로필 미생성 상태
  - `/onboarding`으로 이동하되 잘못된 쿠키 값이 저장되지 않음
- 온보딩 완료 후 브라우저 종료 → 재접속
  - 정상 진입 (쿠키 유지)

## 추후 할 일
- [x] 온보딩 생년월일 입력 개선 #142 