### PR TITLE
[fix] 예산 추천 템플릿 단계별 검증 및 비율 반영 문제 해결

### DIFF
--- a/fe/src/app/(app)/budget/@modal/recommend/loading.tsx
+++ b/fe/src/app/(app)/budget/@modal/recommend/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from '@/components/ui/spinner';
 
 export default function Loading() {
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-black/20 backdrop-blur-[2px]">
-      <div className="bg-muted flex flex-col items-center gap-6 rounded-2xl p-10 shadow-2xl ring-1 ring-black/5">
+    <div className="no-scrollbar fixed inset-0 z-100 flex items-center justify-center overflow-auto bg-black/50">
+      <div className="bg-background flex h-[800px] w-full max-w-[calc(100%-2rem)] flex-col items-center justify-center gap-6 rounded-2xl p-10 shadow-2xl ring-1 ring-black/5 md:max-w-2xl">
         <div className="relative">
           <Spinner className="text-brand h-12 w-12" />
         </div>

--- a/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
+++ b/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
@@ -84,7 +84,7 @@ const BudgetCategoryEditItem = ({
           className={cn(
             'focus-visible:ring-brand-soft h-9 pr-7 text-right text-sm',
             Number(amount) >= MAX_BUDGET_AMOUNT &&
-              'border-destructive/50 focus-visible:ring-destructive/50 border-2'
+              'focus-visible:ring-destructive/50'
           )}
         />
 

--- a/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
+++ b/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
@@ -4,7 +4,9 @@ import { HelpCircle, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { Input } from '@/components/ui/input';
+import { MAX_BUDGET_AMOUNT } from '@/constants/budget';
 import PercentageBadge from '@/components/budgets/common/PercentageBadge';
+import { cn } from '@/lib/utils';
 import { useState } from 'react';
 
 type BudgetCategoryEditItemProps = {
@@ -36,6 +38,14 @@ const BudgetCategoryEditItem = ({
       ? Math.round((Number(amount || 0) / totalBudgetAmount) * 100)
       : 0;
 
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, '');
+
+    if (Number(value) > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+
+    onChange(category.category_key, value);
+  };
+
   return (
     <div className="flex items-center gap-2 py-1">
       {/* 아이콘 원형 배경 */}
@@ -55,7 +65,7 @@ const BudgetCategoryEditItem = ({
       </div>
 
       {/* 금액 입력부 */}
-      <div className="relative w-36">
+      <div className="relative w-38">
         <Input
           ref={inputRef}
           type="text"
@@ -70,9 +80,22 @@ const BudgetCategoryEditItem = ({
           }
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          onChange={(e) => onChange(category.category_key, e.target.value)}
-          className="focus-visible:ring-brand-soft h-9 pr-7 text-right text-sm"
+          onChange={handleAmountChange}
+          className={cn(
+            'focus-visible:ring-brand-soft h-9 pr-7 text-right text-sm',
+            Number(amount) >= MAX_BUDGET_AMOUNT &&
+              'border-destructive/50 focus-visible:ring-destructive/50 border-2'
+          )}
         />
+
+        {isFocused && Number(amount) >= MAX_BUDGET_AMOUNT && (
+          <div className="animate-in fade-in zoom-in absolute -top-6 right-0 duration-200">
+            <span className="text-destructive bg-background rounded border px-2 py-0.5 text-xs font-bold whitespace-nowrap shadow-sm">
+              최대 10억 원까지 가능
+            </span>
+          </div>
+        )}
+
         {amount && (
           <Button
             variant="ghost"

--- a/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
+++ b/fe/src/components/budgets/common/BudgetCategoryEditItem.tsx
@@ -41,7 +41,11 @@ const BudgetCategoryEditItem = ({
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/[^0-9]/g, '');
 
-    if (Number(value) > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+    // 10억 초과 입력 시도 시 10억으로 고정
+    if (Number(value) > MAX_BUDGET_AMOUNT) {
+      onChange(category.category_key, MAX_BUDGET_AMOUNT.toString());
+      return;
+    }
 
     onChange(category.category_key, value);
   };

--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -125,8 +125,9 @@ const BudgetRecommendDialog = ({
     return BUDGET_GROUPS.map((group) => {
       // processedData에서 해당 그룹의 평균 금액 가져오기
       const amount = groupAverages[group.id as CategoryGroupId] || 0;
-      // 전체에서 차지하는 비중 계산 (분모가 0일 경우 대비)
-      const percent = avgTotal > 0 ? Math.round((amount / avgTotal) * 100) : 0;
+      // 전체에서 차지하는 비중 계산 (소수점 첫째 자리까지 계산)
+      const percent =
+        avgTotal > 0 ? Math.round((amount / avgTotal) * 1000) / 10 : 0;
 
       return { ...group, amount, percent };
     });

--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -51,10 +51,14 @@ const BudgetRecommendDialog = ({
   const { step, goalData, budgetDraft, selectedTemplateId, isAdjusted } = state;
 
   const spendableBudget = goalData.income - goalData.savingsAmount; // 가용 예산
+  const isIncomeEmpty = step === 2 && goalData.income <= 0;
 
   // step 이동 버튼 핸들러
   const handleNextStep = () => {
     if (step === 2) {
+      // 수입이 0원인 경우 진행 막기
+      if (isIncomeEmpty) return;
+
       setStep(step + 1);
     } else if (step === 3 && processedData) {
       let result: CalculatedBudgetItem[] = [];
@@ -212,7 +216,7 @@ const BudgetRecommendDialog = ({
               <Button
                 className="h-12 flex-2 cursor-pointer text-base font-bold"
                 onClick={handleNextStep}
-                disabled={isSubmitting}
+                disabled={isSubmitting || isIncomeEmpty}
               >
                 {isSubmitting ? (
                   <div className="flex items-center gap-2">

--- a/fe/src/components/budgets/dialogs/BudgetSetupDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetSetupDialog.tsx
@@ -72,7 +72,11 @@ const BudgetSetupDialog = ({
 
     const value = e.target.value.replace(/[^0-9]/g, '');
 
-    if (Number(value) > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+    // 10억 초과 입력 시도 시 10억으로 고정
+    if (Number(value) > MAX_BUDGET_AMOUNT) {
+      setAmount(MAX_BUDGET_AMOUNT.toString());
+      return;
+    }
 
     setAmount(value);
   };
@@ -116,10 +120,7 @@ const BudgetSetupDialog = ({
                 {amount === '' && <p>예산 금액을 입력해주세요.</p>}
 
                 {numericAmount >= MAX_BUDGET_AMOUNT && (
-                  <p>
-                    최대 {MAX_BUDGET_AMOUNT.toLocaleString()}원까지 설정
-                    가능합니다.
-                  </p>
+                  <p>최대 10억 원까지 설정 가능합니다.</p>
                 )}
               </div>
             )}

--- a/fe/src/components/budgets/dialogs/BudgetSetupDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetSetupDialog.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { THEME_COLOR } from '@/constants/colors';
+import { MAX_BUDGET_AMOUNT } from '@/constants/budget';
 import { toast } from 'sonner';
 import useBudgetData from '@/hooks/useBudgetData';
 
@@ -38,7 +38,8 @@ const BudgetSetupDialog = ({
 
   // 유효성 검사
   const numericAmount = Number(amount);
-  const isInvalid = numericAmount <= 0;
+  const isOverLimit = numericAmount > MAX_BUDGET_AMOUNT; // 10억 초과 여부
+  const isInvalid = numericAmount <= 0 || isOverLimit; // 0 이하이거나 최대치 초과면 Invalid
   // 변경 여부 확인 (기존 값과 비교)
   const isChanged = defaultAmount !== numericAmount;
 
@@ -70,6 +71,9 @@ const BudgetSetupDialog = ({
     if (!isTouched) setIsTouched(true);
 
     const value = e.target.value.replace(/[^0-9]/g, '');
+
+    if (Number(value) > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+
     setAmount(value);
   };
 
@@ -101,15 +105,23 @@ const BudgetSetupDialog = ({
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               onChange={handleAmountChange}
-              className="focus-visible:ring-brand-soft text-lg font-semibold"
+              className="focus-visible:ring-brand-soft font-semibold"
             />
 
-            {isTouched && isInvalid && (
-              <p className={`text-sm ${THEME_COLOR.EXPENSE}`}>
-                {amount === ''
-                  ? '예산 금액을 입력해주세요.'
-                  : '0보다 큰 숫자를 입력해야 합니다.'}
-              </p>
+            {isTouched && (
+              <div className={`text-destructive space-y-1 text-sm`}>
+                {numericAmount <= 0 && amount !== '' && (
+                  <p>0보다 큰 숫자를 입력해야 합니다.</p>
+                )}
+                {amount === '' && <p>예산 금액을 입력해주세요.</p>}
+
+                {numericAmount >= MAX_BUDGET_AMOUNT && (
+                  <p>
+                    최대 {MAX_BUDGET_AMOUNT.toLocaleString()}원까지 설정
+                    가능합니다.
+                  </p>
+                )}
+              </div>
             )}
 
             {!isInvalid && !isChanged && defaultAmount !== undefined && (

--- a/fe/src/components/budgets/steps/BudgetResultStep.tsx
+++ b/fe/src/components/budgets/steps/BudgetResultStep.tsx
@@ -58,8 +58,7 @@ const BudgetResultStep = ({
         step={4}
         subTitle="예산 산출 결과 확인"
         title="이번 달, 이렇게 소비해 보는 건 어떨까요?"
-        description="수입과 지출 습관을 바탕으로 항목별 예산을 나누었습니다. 확인 후 아래
-          버튼을 눌러 이번 달 자산 관리를 시작해 보세요!"
+        description="최근 지출 패턴을 분석하여 항목별 최적 예산을 제안해 드려요. 확인 후 아래 버튼을 눌러 계획적인 자산 관리를 시작해 보세요!"
       />
 
       {/* 조정 상태 피드백 섹션 */}
@@ -137,8 +136,8 @@ const BudgetResultStep = ({
             </div>
           </div>
 
-          <div className="text-muted-foreground flex gap-1 text-xs">
-            <Info className="h-3.5 w-3.5 shrink-0" />
+          <div className="text-muted-foreground flex items-center gap-1 text-xs">
+            <Info className="h-3 w-3 shrink-0" />
             <p>수입에서 저축 목표를 제외한 금액입니다.</p>
           </div>
         </Card>
@@ -166,11 +165,10 @@ const BudgetResultStep = ({
         />
       </section>
 
-      <div className="text-muted-foreground flex gap-1 px-2 text-xs">
-        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <div className="text-muted-foreground flex items-center gap-1 px-2 text-xs">
+        <Info className="mt-0.5 h-3 w-3 shrink-0" />
         <p className="break-keep">
-          과거 소비 비중을 바탕으로 산출된 예산입니다. 100원 단위 미만의 잔돈은
-          가장 지출 비중이 높은 항목에 자동으로 포함되었습니다.
+          과거 소비 비중을 반영해 관리하기 편한 100원 단위로 산출되었습니다.
         </p>
       </div>
     </div>

--- a/fe/src/components/budgets/steps/BudgetResultStep.tsx
+++ b/fe/src/components/budgets/steps/BudgetResultStep.tsx
@@ -46,9 +46,11 @@ const BudgetResultStep = ({
     0
   );
 
-  // 전체 예산 대비 그룹별 비중(%) 계산
-  const getPercent = (total: number) =>
-    Math.round((total / (spendableBudget || 1)) * 100);
+  // 1. 전체 예산 대비 그룹별 비중(%) 계산 (소수점 첫째 자리까지)
+  const getPercent = (total: number) => {
+    if (!spendableBudget || spendableBudget === 0) return 0;
+    return Math.round((total / spendableBudget) * 1000) / 10;
+  };
 
   return (
     <div className="flex flex-col gap-6">

--- a/fe/src/components/budgets/steps/ExpenseAnalysisStep.tsx
+++ b/fe/src/components/budgets/steps/ExpenseAnalysisStep.tsx
@@ -32,7 +32,7 @@ const ExpenseAnalysisStep = ({
           <>
             최근 {activeMonths}개월간 월 평균{' '}
             <span className="text-brand">
-              {Math.floor(avgTotal).toLocaleString()}원
+              {Math.round(avgTotal).toLocaleString()}원
             </span>
             을 지출했어요
           </>
@@ -72,7 +72,7 @@ const ExpenseAnalysisStep = ({
                 className="flex h-full flex-1 flex-col items-center justify-end gap-2"
               >
                 <span className="text-xs font-bold tracking-tight">
-                  {Math.floor(m.total).toLocaleString()}원
+                  {Math.round(m.total).toLocaleString()}원
                 </span>
                 <div
                   style={{ height: `${height * 0.8}%` }}
@@ -130,7 +130,7 @@ const ExpenseAnalysisStep = ({
               </div>
               <div className="text-right">
                 <div className="text-sm font-bold">
-                  {Math.floor(g.amount).toLocaleString()}원
+                  {Math.round(g.amount).toLocaleString()}원
                 </div>
                 <div className="text-xs">{g.percent}%</div>
               </div>

--- a/fe/src/components/budgets/steps/SavingGoalStep.tsx
+++ b/fe/src/components/budgets/steps/SavingGoalStep.tsx
@@ -2,6 +2,7 @@ import DialogStepHeader from '@/components/budgets/steps/DialogStepHeader';
 import { Label } from '@/components/ui/label';
 import { MAX_BUDGET_AMOUNT } from '@/constants/budget';
 import { Slider } from '@/components/ui/slider';
+import { useState } from 'react';
 
 type SavingGoalStepProps = {
   income: number;
@@ -14,6 +15,9 @@ const SavingGoalStep = ({
   savingsAmount,
   onChange,
 }: SavingGoalStepProps) => {
+  const [isIncomeFocused, setIsIncomeFocused] = useState(false);
+  const [isSavingsFocused, setIsSavingsFocused] = useState(false);
+
   const savingsRate =
     income > 0 ? Math.round((savingsAmount / income) * 100) : 0;
   const spendableBudget = income - savingsAmount || 0;
@@ -95,7 +99,15 @@ const SavingGoalStep = ({
             id="income"
             type="text"
             inputMode="numeric"
-            value={income || ''}
+            value={
+              isIncomeFocused
+                ? income || ''
+                : income !== 0
+                  ? income.toLocaleString()
+                  : ''
+            }
+            onFocus={() => setIsIncomeFocused(true)}
+            onBlur={() => setIsIncomeFocused(false)}
             onChange={handleIncomeChange}
             className="w-32 text-right text-lg font-bold focus:outline-none"
             placeholder="0"
@@ -118,8 +130,15 @@ const SavingGoalStep = ({
               id="saving"
               type="text"
               inputMode="numeric"
-              pattern="[0-9]*"
-              value={savingsAmount || ''}
+              value={
+                isSavingsFocused
+                  ? savingsAmount || ''
+                  : savingsAmount !== 0
+                    ? savingsAmount.toLocaleString()
+                    : ''
+              }
+              onFocus={() => setIsSavingsFocused(true)}
+              onBlur={() => setIsSavingsFocused(false)}
               onChange={handleAmountChange}
               className="w-32 text-right text-lg font-bold focus:outline-none"
               placeholder="0"

--- a/fe/src/components/budgets/steps/SavingGoalStep.tsx
+++ b/fe/src/components/budgets/steps/SavingGoalStep.tsx
@@ -1,6 +1,6 @@
-import { AlertTriangle } from 'lucide-react';
 import DialogStepHeader from '@/components/budgets/steps/DialogStepHeader';
 import { Label } from '@/components/ui/label';
+import { MAX_BUDGET_AMOUNT } from '@/constants/budget';
 import { Slider } from '@/components/ui/slider';
 
 type SavingGoalStepProps = {
@@ -26,11 +26,26 @@ const SavingGoalStep = ({
     onChange(income, newAmount);
   };
 
+  // 수입 입력 시
+  const handleIncomeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value.replace(/[^0-9]/g, ''));
+
+    if (value > MAX_BUDGET_AMOUNT) return;
+
+    const newIncome = value;
+    // 현재 설정된 저축률(savingsRate)에 맞춰 저축 금액 업데이트
+    const newAmount = Math.floor((newIncome * savingsRate) / 100);
+
+    onChange(newIncome, newAmount);
+  };
+
   // 금액 입력 시
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value.replace(/[^0-9]/g, ''));
-    let newAmount = value;
 
+    if (value > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+
+    let newAmount = value;
     // 70% 제한 로직
     if (income > 0) {
       const calculatedRate = Math.round((value / income) * 100);
@@ -40,15 +55,6 @@ const SavingGoalStep = ({
     }
 
     onChange(income, newAmount);
-  };
-
-  // 수입 입력 시
-  const handleIncomeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newIncome = Number(e.target.value);
-    // 현재 설정된 저축률(savingsRate)에 맞춰 저축 금액 업데이트
-    const newAmount = Math.floor((newIncome * savingsRate) / 100);
-
-    onChange(newIncome, newAmount);
   };
 
   const titleDesc =
@@ -73,9 +79,13 @@ const SavingGoalStep = ({
           </Label>
 
           {income === 0 && (
-            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 text-xs font-medium">
-              <AlertTriangle className="h-3 w-3" />
+            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 text-xs">
               수입을 먼저 입력해 주세요.
+            </p>
+          )}
+          {income >= MAX_BUDGET_AMOUNT && (
+            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 text-xs">
+              최대 10억 원까지 입력 가능합니다.
             </p>
           )}
         </div>
@@ -135,8 +145,7 @@ const SavingGoalStep = ({
 
           {/* 최대치 도달 시 문구 표시 */}
           {savingsRate >= 70 && (
-            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 pt-4 text-xs">
-              <AlertTriangle className="h-3 w-3" />
+            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 text-xs">
               저축 목표는 최대 70%까지 설정할 수 있어요.
             </p>
           )}

--- a/fe/src/components/budgets/steps/SavingGoalStep.tsx
+++ b/fe/src/components/budgets/steps/SavingGoalStep.tsx
@@ -67,10 +67,17 @@ const SavingGoalStep = ({
 
       {/* 수입 입력 섹션 */}
       <div className="flex items-center justify-between rounded-xl">
-        <div className="flex items-center">
+        <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-4">
           <Label htmlFor="income" className="text-base font-bold">
             이번 달 예상 수입
           </Label>
+
+          {income === 0 && (
+            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 text-xs font-medium">
+              <AlertTriangle className="h-3 w-3" />
+              수입을 먼저 입력해 주세요.
+            </p>
+          )}
         </div>
 
         <div className="border-primary/20 focus-within:border-brand flex w-fit items-center gap-1 border-b-2">
@@ -128,7 +135,7 @@ const SavingGoalStep = ({
 
           {/* 최대치 도달 시 문구 표시 */}
           {savingsRate >= 70 && (
-            <p className="animate-in fade-in slide-in-from-top-1 flex items-center gap-1 pt-4 text-xs text-orange-400">
+            <p className="animate-in fade-in slide-in-from-top-1 text-destructive flex items-center gap-1 pt-4 text-xs">
               <AlertTriangle className="h-3 w-3" />
               저축 목표는 최대 70%까지 설정할 수 있어요.
             </p>

--- a/fe/src/components/budgets/steps/SavingGoalStep.tsx
+++ b/fe/src/components/budgets/steps/SavingGoalStep.tsx
@@ -34,22 +34,23 @@ const SavingGoalStep = ({
   const handleIncomeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value.replace(/[^0-9]/g, ''));
 
-    if (value > MAX_BUDGET_AMOUNT) return;
+    let newIncome = value;
+    if (value > MAX_BUDGET_AMOUNT) {
+      newIncome = MAX_BUDGET_AMOUNT;
+    }
 
-    const newIncome = value;
     // 현재 설정된 저축률(savingsRate)에 맞춰 저축 금액 업데이트
     const newAmount = Math.floor((newIncome * savingsRate) / 100);
 
     onChange(newIncome, newAmount);
   };
 
-  // 금액 입력 시
+  // 저축 금액 입력 시
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value.replace(/[^0-9]/g, ''));
 
-    if (value > MAX_BUDGET_AMOUNT) return; // 10억 초과 입력 방지
+    let newAmount = value > MAX_BUDGET_AMOUNT ? MAX_BUDGET_AMOUNT : value;
 
-    let newAmount = value;
     // 70% 제한 로직
     if (income > 0) {
       const calculatedRate = Math.round((value / income) * 100);

--- a/fe/src/constants/budget.ts
+++ b/fe/src/constants/budget.ts
@@ -4,6 +4,8 @@ import {
   GroupInfo,
 } from '@/types/budgetGuide';
 
+export const MAX_BUDGET_AMOUNT = 1000000000 as const; // 10억
+
 /** 카테고리별 그룹 매핑 */
 export const EXPENSE_CATEGORY_GROUP_MAP: Record<string, CategoryGroupId> = {
   // Essential (필수)

--- a/fe/src/constants/budget.ts
+++ b/fe/src/constants/budget.ts
@@ -55,14 +55,15 @@ export const BUDGET_TEMPLATES: BudgetTemplate[] = [
     id: 'keep-pattern',
     title: '지출 패턴 유지',
     subtitle: '현재 상태 유지',
-    description: '최근 3개월 소비 비율을 그대로 유지하여 예산을 짭니다.',
+    description:
+      '최근 소비 비중을 반영하여 익숙한 패턴 안에서 예산을 설정합니다.',
     // 비율 제한 없음 (기존 데이터 그대로)
   },
   {
     id: 'save-flexible',
     title: '유연 지출 절감형',
     subtitle: 'Flexible ≤ 40%',
-    description: '쇼핑, 외식 등 유연 지출을 40% 이하로 줄여 예산을 짭니다.',
+    description: '유연 지출을 40% 이내로 조정하여 불필요한 지출을 줄입니다.',
     flexibleLimitRatio: 0.4,
   },
   {
@@ -70,7 +71,7 @@ export const BUDGET_TEMPLATES: BudgetTemplate[] = [
     title: '강력 절약형',
     subtitle: 'Flexible ≤ 30%',
     description:
-      '꼭 필요한 지출 위주로 70%를 배분하고 유연 지출을 30%로 제한합니다.',
+      '유연 지출을 30% 이하로 엄격히 제한하여 불필요한 지출을 최소화합니다.',
     flexibleLimitRatio: 0.3,
   },
 ] as const;

--- a/fe/src/utils/calculateBudget.ts
+++ b/fe/src/utils/calculateBudget.ts
@@ -1,143 +1,182 @@
 import { CalculatedBudgetItem, CategoryStat } from '@/types/budgetGuide';
 
-// 기본 비중 배분 함수
-const getBasicDraft = (
-  spendableBudget: number,
-  categoryStats: Record<string, CategoryStat>
+// 그룹 내에서 예산 배분 및 자투리 보정 (공통 로직)
+const distributeGroupBudget = (
+  items: [string, CategoryStat][],
+  targetTotal: number,
+  totalBudget: number
 ): CalculatedBudgetItem[] => {
-  const statsArray = Object.entries(categoryStats);
-  // 과거 지출 총합 (가중치 계산용)
-  const totalPastAvg = statsArray.reduce(
+  // 그룹 내 과거 지출 총합 계산
+  const groupPastTotal = items.reduce(
     (sum, [_, stat]) => sum + stat.avgAmount,
     0
   );
 
-  // 과거 데이터가 없는 경우 균등 배분
-  if (totalPastAvg === 0) {
-    const count = statsArray.length;
-    const equalAmount = Math.floor(spendableBudget / count / 100) * 100;
+  // 각 항목별 금액 1차 계산 (내림 처리)
+  const calculatedItems = items.map(([id, stat]) => {
+    // 그룹 내에서의 비중 계산
+    const localWeight =
+      groupPastTotal === 0 ? 1 / items.length : stat.avgAmount / groupPastTotal;
 
-    return statsArray.map(([id, stat]) => ({
-      categoryId: id,
-      name: stat.name,
-      groupId: stat.groupId,
-      amount: equalAmount,
-      weight: 1 / count,
-    }));
-  }
-
-  // 비중대로 배분 및 100원 단위 절삭
-  return statsArray.map(([id, stat]) => {
-    const weight = stat.avgAmount / totalPastAvg; // 비중(가중치) 계산
-    const rawAmount = spendableBudget * weight; // 가중치 적용
-    const amount = Math.floor(rawAmount / 100) * 100; // 100원 단위 절삭
+    // 목표 금액에 비중을 곱해 금액 산출 (100원 단위 내림)
+    const amount = Math.floor((targetTotal * localWeight) / 100) * 100;
 
     return {
       categoryId: id,
       name: stat.name,
       groupId: stat.groupId,
       amount,
-      weight,
+      weight: 0,
     };
   });
-};
 
-// 자투리 금액 보정 함수 (총액 맞추기)
-const fillGap = (
-  items: CalculatedBudgetItem[],
-  targetTotal: number
-): CalculatedBudgetItem[] => {
-  const currentTotal = items.reduce((sum, item) => sum + item.amount, 0);
-  const gap = targetTotal - currentTotal;
-
-  if (gap <= 0) return items;
-
-  // 가장 비중이 큰 항목에 차액 합산
-  const topItem = items.reduce((prev, curr) =>
-    prev.amount > curr.amount ? prev : curr
+  // 자투리 금액 계산 및 보정 (같은 그룹 내에서 비중이 큰 순서대로 100원씩 분배)
+  const currentTotal = calculatedItems.reduce(
+    (sum, item) => sum + item.amount,
+    0
   );
-  topItem.amount += gap;
+  let gap = targetTotal - currentTotal;
 
-  return items;
+  if (gap > 0) {
+    // 과거 평균 지출액이 큰 순서대로 정렬하여 100원씩 분배
+    const sortedIndices = calculatedItems
+      .map((item, index) => ({ index, amount: item.amount }))
+      .sort((a, b) => b.amount - a.amount); // 금액 큰 순
+
+    let i = 0;
+    while (gap > 0) {
+      const targetIndex = sortedIndices[i % sortedIndices.length].index;
+      calculatedItems[targetIndex].amount += 100;
+      gap -= 100;
+      i++;
+    }
+  }
+
+  // 최종 비중 갱신 및 반환
+  return calculatedItems.map((item) => ({
+    ...item,
+    weight: item.amount / totalBudget,
+  }));
 };
 
-// 지출 패턴 유지 예산 산출
+// 지출 패턴 유지 (Keep Pattern)
 export const calculateKeepPatternBudget = (
   spendableBudget: number,
   categoryStats: Record<string, CategoryStat>
 ): CalculatedBudgetItem[] => {
-  if (Object.keys(categoryStats).length === 0) return [];
+  const statsArray = Object.entries(categoryStats);
+  if (statsArray.length === 0) return [];
 
-  // 비중대로 나누기
-  const distributedItems = getBasicDraft(spendableBudget, categoryStats);
+  // 전체 데이터 기준, 그룹별 비중 계산
+  const totalPastAvg = statsArray.reduce(
+    (sum, [_, stat]) => sum + stat.avgAmount,
+    0
+  );
 
-  // 자투리 금액 보정하여 최종 반환
-  return fillGap(distributedItems, spendableBudget).sort(
+  // 필수 지출 그룹의 과거 총액
+  const essentialPastTotal = statsArray
+    .filter(([_, stat]) => stat.groupId !== 'flexible')
+    .reduce((sum, [_, stat]) => sum + stat.avgAmount, 0);
+
+  // 필수 지출 비중
+  const essentialRatio =
+    totalPastAvg === 0 ? 0.5 : essentialPastTotal / totalPastAvg;
+
+  // 그룹별 목표 금액 확정
+  const targetEssentialTotal =
+    Math.floor((spendableBudget * essentialRatio) / 100) * 100;
+
+  const targetFlexibleTotal = spendableBudget - targetEssentialTotal;
+
+  // 그룹별 배분
+  const essentialItems = statsArray.filter(
+    ([_, stat]) => stat.groupId !== 'flexible'
+  );
+  const flexibleItems = statsArray.filter(
+    ([_, stat]) => stat.groupId === 'flexible'
+  );
+
+  const finalEssential = distributeGroupBudget(
+    essentialItems,
+    targetEssentialTotal,
+    spendableBudget
+  );
+  const finalFlexible = distributeGroupBudget(
+    flexibleItems,
+    targetFlexibleTotal,
+    spendableBudget
+  );
+
+  // 결과 반환
+  return [...finalEssential, ...finalFlexible].sort(
     (a, b) => b.amount - a.amount
   );
 };
 
-// 유연 지출 절감형/강력 절약형 공통 예산 산출 함수
+// 유연 지출 조정
 export const calculateSaveFlexible = (
   spendableBudget: number,
   categoryStats: Record<string, CategoryStat>,
   maxFlexibleRatio: number
 ): { items: CalculatedBudgetItem[]; isAdjusted: boolean } => {
-  if (Object.keys(categoryStats).length === 0)
-    return { items: [], isAdjusted: false };
+  const statsArray = Object.entries(categoryStats);
+  if (statsArray.length === 0) return { items: [], isAdjusted: false };
 
-  // 과거 비중으로 먼저 계산
-  const distributedItems = getBasicDraft(spendableBudget, categoryStats);
+  // 조정 여부 판단
+  const totalPastAvg = statsArray.reduce(
+    (sum, [_, stat]) => sum + stat.avgAmount,
+    0
+  );
 
-  // 현재 유연 지출(flexible) 그룹의 총 비중 계산
-  const currentFlexibleTotal = distributedItems
-    .filter((item) => item.groupId === 'flexible')
-    .reduce((sum, item) => sum + item.amount, 0);
+  const flexiblePastTotal = statsArray
+    .filter(([_, stat]) => stat.groupId === 'flexible')
+    .reduce((sum, [_, stat]) => sum + stat.avgAmount, 0);
 
-  const currentFlexibleRatio = currentFlexibleTotal / spendableBudget;
-
-  // 조정이 필요한지 확인 (상한선보다 클 때만 조정)
+  const currentFlexibleRatio =
+    totalPastAvg === 0 ? 0 : flexiblePastTotal / totalPastAvg;
   const isAdjusted = currentFlexibleRatio > maxFlexibleRatio;
 
-  if (!isAdjusted) {
-    // 조정이 필요 없으면 원본에 차액만 보정해서 반환
-    return {
-      items: fillGap(distributedItems, spendableBudget),
-      isAdjusted: false,
-    };
+  // 그룹별 목표 금액 확정
+  let targetEssentialTotal: number;
+  let targetFlexibleTotal: number;
+
+  if (isAdjusted) {
+    // 조정 필요 시 유연 지출을 제한 비율에 맞춤 (나머지는 필수 지출)
+    targetFlexibleTotal =
+      Math.floor((spendableBudget * maxFlexibleRatio) / 100) * 100;
+    targetEssentialTotal = spendableBudget - targetFlexibleTotal;
+  } else {
+    // 조정 불필요 시 기존 비율 유지
+    const essentialRatio = 1 - currentFlexibleRatio;
+    targetEssentialTotal =
+      Math.floor((spendableBudget * essentialRatio) / 100) * 100;
+    targetFlexibleTotal = spendableBudget - targetEssentialTotal;
   }
 
-  // 조정 로직: 유연 지출을 상한선 금액으로 강제 고정
-  const targetFlexibleTotal = spendableBudget * maxFlexibleRatio;
-  const targetEssentialTotal = spendableBudget - targetFlexibleTotal;
+  // 그룹별 배분
+  const essentialItems = statsArray.filter(
+    ([_, stat]) => stat.groupId !== 'flexible'
+  );
+  const flexibleItems = statsArray.filter(
+    ([_, stat]) => stat.groupId === 'flexible'
+  );
 
-  // 그룹별 내에서 다시 비중 재배분
-  const adjustedItems = distributedItems.map((item) => {
-    if (item.groupId === 'flexible') {
-      // 유연 그룹 내에서의 상대적 비중 계산
-      const groupWeight = item.amount / currentFlexibleTotal;
+  const finalEssential = distributeGroupBudget(
+    essentialItems,
+    targetEssentialTotal,
+    spendableBudget
+  );
+  const finalFlexible = distributeGroupBudget(
+    flexibleItems,
+    targetFlexibleTotal,
+    spendableBudget
+  );
 
-      return {
-        ...item,
-        amount: Math.floor((targetFlexibleTotal * groupWeight) / 100) * 100,
-      };
-    } else {
-      // 필수/고정 그룹 합산 (essential)
-      const currentEssentialTotal = spendableBudget - currentFlexibleTotal;
-      const groupWeight = item.amount / currentEssentialTotal;
-
-      return {
-        ...item,
-        amount: Math.floor((targetEssentialTotal * groupWeight) / 100) * 100,
-      };
-    }
-  });
-
-  // 자투리 보정 및 반환
+  // 결과 반환
   return {
-    items: fillGap(adjustedItems, spendableBudget).sort(
+    items: [...finalEssential, ...finalFlexible].sort(
       (a, b) => b.amount - a.amount
     ),
-    isAdjusted: true,
+    isAdjusted,
   };
 };

--- a/fe/src/utils/calculateBudget.ts
+++ b/fe/src/utils/calculateBudget.ts
@@ -6,6 +6,9 @@ const distributeGroupBudget = (
   targetTotal: number,
   totalBudget: number
 ): CalculatedBudgetItem[] => {
+  // 필수/유연 중 한 그룹이 아예 비어있을 때
+  if (items.length === 0) return [];
+
   // 그룹 내 과거 지출 총합 계산
   const groupPastTotal = items.reduce(
     (sum, [_, stat]) => sum + stat.avgAmount,
@@ -37,14 +40,14 @@ const distributeGroupBudget = (
   );
   let gap = targetTotal - currentTotal;
 
-  if (gap > 0) {
+  if (gap > 0 && calculatedItems.length > 0) {
     // 과거 평균 지출액이 큰 순서대로 정렬하여 100원씩 분배
     const sortedIndices = calculatedItems
       .map((item, index) => ({ index, amount: item.amount }))
       .sort((a, b) => b.amount - a.amount); // 금액 큰 순
 
     let i = 0;
-    while (gap > 0) {
+    while (gap > 0 && sortedIndices.length > 0) {
       const targetIndex = sortedIndices[i % sortedIndices.length].index;
       calculatedItems[targetIndex].amount += 100;
       gap -= 100;


### PR DESCRIPTION
## PR 개요
- 예산 추천 플로우 전반의 입력 안정성과 계산 정확도를 개선했습니다.

## 변경 사항
### 1. 예산 추천 입력/로딩 UI 안정성 개선
- 예산 추천 로딩 UI 높이를 다이얼로그와 일치하도록 수정
- 수입 미입력 시 예산 추천 진행 제한
  - 수입이 `0원`일 경우 다음 단계 이동 차단
  - 버튼 비활성화 및 안내 문구 노출
- 월 예산 최대 입력 금액 제한 및 안내 메시지 추가
  - `MAX_BUDGET_AMOUNT` (10억) 상수 추가
  - 정수 범위 초과로 저장되지 않는 문제 방지
- 카테고리별 예산 설정 시 최대 금액 제한 및 안내 메시지 추가
- 추천 예산 설정(`step2`) 수입/저축 입력 시 최대 금액 제한 및 안내 메시지 추가
- 수입 및 저축 목표 입력창 금액 포맷팅(`toLocaleString`) 적용
  - `isFocused` 상태에 따른 조건부 포맷 표시

### 2. 예산 비중 계산 정밀도 및 산출 로직 개선
- 예산 비중 UI 표시 정밀도 개선 (소수점 첫째 자리)
- 소비 분석 단계 금액 표시 오차 수정
  - `floor` → `round`로 변경하여 합계 오차 제거
- 예산 산출 로직 구조 개선
  > 변경 전: 카테고리 단위 비중 배분 → 이후 유연 지출 비율 보정
  > 변경 후: 그룹(필수/유연) 총 예산을 먼저 확정 → 그룹 내부에서 비중 배분
  - 그룹별 목표 금액을 먼저 계산하도록 로직 변경
  - 그룹 내부에서 과거 소비 비중에 따라 재배분
  - 자투리 금액 발생 시 그룹 내 상위 항목들에 100원 단위로 순차 분배
  - 공통 배분 함수 `distributeGroupBudget` 분리
  - 특정 그룹 내 데이터가 없을 경우 빈 배열 반환하도록 예외 처리
- 예산 추천 템플릿 설명 문구 개선
- 예산 추천 결과 화면 안내 문구 개선

## 스크린샷 (선택)
### 1. 예산 추천 step2 - 수입 0원인 경우
| Before | After |
|------------|------------|
| ![BudgetRecommendStep2IncomeZero_before](https://github.com/user-attachments/assets/37c3d833-4744-4e79-9777-8a390cd02fe3) | <img width="800" height="1000" alt="BudgetRecommendStep2IncomeZero_after" src="https://github.com/user-attachments/assets/eb3f80e4-d238-433f-8127-2feaeed06fcc" /> |

### 2. 예산 금액 저장 제한 (최대 10억 제한)
**총 예산 설정**
| Before | After |
|------------|------------|
| ![TotalBudgetSave_before](https://github.com/user-attachments/assets/dbbc9cc2-9eaf-4b07-970e-7a2e1beb1bf0) | ![TotalBudgetSave_after](https://github.com/user-attachments/assets/78074791-77c4-48c0-b853-fb1f381af171) |

**카테고리별 예산 설정**
| Before | After |
|------------|------------|
| ![CategoryBudgetSave_before](https://github.com/user-attachments/assets/ffdd0346-2d61-400c-b1d3-82f28c5f2097) | ![CategoryBudgetSave_after](https://github.com/user-attachments/assets/c4d9624a-4293-43ae-8ac9-57f56fda1eea) |

**예산 추천 step2 예산 설정**
| Before | After |
|------------|------------|
| ![BudgetRecommendStep2Income_before](https://github.com/user-attachments/assets/5db7853c-16f7-4016-b5d0-3769bbd2e538) | ![BudgetRecommendStep2Income_after](https://github.com/user-attachments/assets/c771b456-00ad-411c-b842-23439204add0) |

### 3. 예산 산정 개선
| Before | After |
|------------|------------|
| ![BudgetRecommendResult_before](https://github.com/user-attachments/assets/1db8db6b-4a01-4941-8e4d-0a7cc7280436) | ![BudgetRecommendResult_after](https://github.com/user-attachments/assets/830224dc-5b88-4df4-9c02-55782420bc37) |


## 리뷰 요청 사항
1. `예산 템플릿 step2`에서 수입이 `0원`일 때 버튼 비활성화와 안내 문구가 제대로 노출 되는지 확인 부탁드립니다.
2. 예산 설정 시 10억 초과 금액 입력 및 저장이 정상적으로 제한되는지 확인 부탁드립니다.
    - `총 예산 입력`
    - `카테고리별 예산 입력`
    - `예산 템플릿 step2`
    - 각 경우에서 입력 제한 / 안내 문구 / 저장 차단이 의도대로 동작하는지 확인 부탁드립니다.
4. 예산 산정 템플릿 적용 시
    - 템플릿별(지출 패턴 유지 / 유연 지출 절감형 / 강력 절약형) 예산 비중이 의도한 대로 계산되는지
    - 필수/유연 그룹 비율이 자연스럽게 분배되는지
    - 카테고리 금액 합계가 월 예산과 정확히 일치하는지
확인 부탁드립니다.


## 추후 할 일
- [ ] Header/Navigation UI 개선