### PR TITLE
[design] Header / Navigation UI 개선

### DIFF
--- a/fe/src/app/(app)/analysis/page.tsx
+++ b/fe/src/app/(app)/analysis/page.tsx
@@ -61,7 +61,7 @@ const AnalysisPage = async ({ searchParams }: AnalysisPageProps) => {
   ];
 
   return (
-    <div className="flex min-h-screen w-full flex-col py-4">
+    <div className="flex w-full flex-col py-4">
       {/* 달 이동 */}
       <MonthNavigator year={year} month={month} baseUrl="/analysis" />
 

--- a/fe/src/app/(app)/budget/@modal/recommend/loading.tsx
+++ b/fe/src/app/(app)/budget/@modal/recommend/loading.tsx
@@ -3,7 +3,7 @@ import { Spinner } from '@/components/ui/spinner';
 export default function Loading() {
   return (
     <div className="no-scrollbar fixed inset-0 z-100 flex items-center justify-center overflow-auto bg-black/50">
-      <div className="bg-background flex h-[800px] w-full max-w-[calc(100%-2rem)] flex-col items-center justify-center gap-6 rounded-2xl p-10 shadow-2xl ring-1 ring-black/5 md:max-w-2xl">
+      <div className="bg-background flex h-[80dvh] w-full max-w-[calc(100%-2rem)] flex-col items-center justify-center gap-6 rounded-2xl p-10 shadow-2xl ring-1 ring-black/5 md:h-[800px] md:max-w-2xl">
         <div className="relative">
           <Spinner className="text-brand h-12 w-12" />
         </div>

--- a/fe/src/app/(app)/budget/page.tsx
+++ b/fe/src/app/(app)/budget/page.tsx
@@ -39,7 +39,7 @@ const BudgetPage = async ({ searchParams }: BudgetPageProps) => {
   );
 
   return (
-    <div className="flex min-h-screen w-full flex-col py-4">
+    <div className="flex w-full flex-col py-4">
       <MonthNavigator year={year} month={month} baseUrl="/budget" />
 
       <div className="mx-auto w-full max-w-4xl px-6 md:px-12">

--- a/fe/src/app/(app)/fixed-costs/page.tsx
+++ b/fe/src/app/(app)/fixed-costs/page.tsx
@@ -1,12 +1,13 @@
+import { formatLocalDate, parseLocalDate } from '@/utils/date';
+
+import type { FixedCostsFilters as Filters } from '@/types/fixed-costs';
 import FixedCostsClient from '@/components/fixed-costs/FixedCostsClient';
+import FixedCostsFilters from '@/components/fixed-costs/FixedCostsFilters';
 import FixedCostsList from '@/components/fixed-costs/FixedCostsList';
 import FixedCostsListSkeleton from '@/components/fixed-costs/FixedCostsListSkeleton';
-import { fetchFixedRulesServer } from '@/services/fixed-costs/fixedCostsServer';
-import { Suspense } from 'react';
 import { FixedCostsProvider } from './FixedCostsContext';
-import FixedCostsFilters from '@/components/fixed-costs/FixedCostsFilters';
-import type { FixedCostsFilters as Filters } from '@/types/fixed-costs';
-import { formatLocalDate, parseLocalDate } from '@/utils/date';
+import { Suspense } from 'react';
+import { fetchFixedRulesServer } from '@/services/fixed-costs/fixedCostsServer';
 
 interface PageProps {
   searchParams: Promise<{
@@ -40,7 +41,7 @@ export default async function FixedCostsPage({ searchParams }: PageProps) {
 
   return (
     <FixedCostsProvider>
-      <div className="flex min-h-screen w-full flex-col">
+      <div className="flex w-full flex-col">
         <div className="flex w-full flex-col items-center space-y-6 p-4 md:p-6 lg:p-8">
           <div className="w-full max-w-xl space-y-6">
             <header>

--- a/fe/src/app/(app)/layout.tsx
+++ b/fe/src/app/(app)/layout.tsx
@@ -9,18 +9,21 @@ const AppLayout = ({
   children: React.ReactNode;
 }>) => {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-dvh flex-col">
       <Header />
 
-      <div className="flex flex-1 flex-col pt-16 md:flex-row">
+      <div className="flex flex-1 flex-col pt-16">
         <Navigation />
 
-        <div className="flex w-full flex-col md:pl-28">
+        <div className="flex w-full flex-col pb-18 md:pb-0 md:pl-28">
           <main className="flex flex-1 justify-center">{children}</main>
-          <Footer />
         </div>
 
         <Toaster />
+      </div>
+
+      <div className="hidden md:block">
+        <Footer />
       </div>
     </div>
   );

--- a/fe/src/app/(app)/page.tsx
+++ b/fe/src/app/(app)/page.tsx
@@ -1,27 +1,28 @@
-import { getTransaction, getMonthTransactions } from './history/actions';
-import { Suspense } from 'react';
 import { formatLocalDate, formatMonth } from '@/utils/date';
-import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
-import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
-import { getTotalBudgetAmount } from '@/utils/budget';
-import { fetchBudgetsServer } from '@/services/budgets/budget';
+import { getMonthTransactions, getTransaction } from './history/actions';
 import {
   sumExpenseUntilYesterday,
   sumFixedExpenseUntilYesterday,
 } from '@/utils/transaction';
-import { fetchFixedRulesByMonthServer } from '@/services/fixed-costs/fixedCostsServer';
-import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs/fixedCosts';
+
+import { CalendarClient } from '@/components/calendar/CalendarClient';
+import { CalendarSkeleton } from '@/components/calendar/CalendarSkeleton';
+import { DailyRecBar } from '@/components/daily-recommendation/DailyRecBar';
+import { SpendingTransaction } from '@/services/daily-recommendation/spendingPattern';
+import { Suspense } from 'react';
 import { buildDailyRecChartData } from '@/services/daily-recommendation/chart';
 import { calculateDailyRec } from '@/services/daily-recommendation/calculate';
-import { SpendingTransaction } from '@/services/daily-recommendation/spendingPattern';
-import { CalendarClient } from '@/components/calendar/CalendarClient';
+import { fetchBudgetsServer } from '@/services/budgets/budget';
+import { fetchFixedRulesByMonthServer } from '@/services/fixed-costs/fixedCostsServer';
+import { getFixedPlannedExpenseByMonth } from '@/utils/fixed-costs/fixedCosts';
+import { getTotalBudgetAmount } from '@/utils/budget';
 
 export default async function Home() {
   const today = new Date();
   const currentMonth = formatMonth(today);
 
   return (
-    <div className="flex min-h-screen w-full max-w-6xl self-start">
+    <div className="flex w-full max-w-6xl self-start">
       <Suspense fallback={<CalendarSkeleton />}>
         <InitialDataLoader currentMonth={currentMonth} />
       </Suspense>

--- a/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
+++ b/fe/src/components/budgets/dialogs/BudgetRecommendDialog.tsx
@@ -149,7 +149,7 @@ const BudgetRecommendDialog = ({
         onOpenChange(isOpen);
       }}
     >
-      <DialogContent className="flex h-[800px] w-full flex-col md:max-w-2xl">
+      <DialogContent className="flex h-[80dvh] w-full flex-col md:h-[800px] md:max-w-2xl">
         {/* 상단 Step 표시 */}
         <div className="px-6 pt-6">
           <Progress value={(step / 4) * 100} className="[&>div]:bg-brand h-2" />

--- a/fe/src/components/common/NavItem.tsx
+++ b/fe/src/components/common/NavItem.tsx
@@ -2,25 +2,44 @@ import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
-const NavItem = ({
-  label,
-  href,
-  isActive,
-}: {
+type NavItemProps = {
   label: string;
   href: string;
   isActive: boolean;
-}) => {
+  itemIcon: React.ComponentType<{ className?: string }>;
+};
+
+const NavItem = ({ label, href, isActive, itemIcon: Icon }: NavItemProps) => {
   return (
     <Button
       asChild
       variant="ghost"
       className={cn(
-        'hover:bg-brand/10 active:bg-brand/20 dark:hover:bg-brand/10 dark:active:bg-brand/20 duration-200 md:h-20 md:w-24',
-        isActive ? 'bg-brand/10 font-bold' : 'font-normal'
+        'relative flex h-full flex-1 flex-col items-center justify-center gap-1 rounded-lg px-2 py-1 transition-all duration-200',
+        'md:h-20 md:w-24 md:flex-none md:rounded-md',
+        'hover:bg-brand/15 active:bg-brand/20',
+        isActive ? 'bg-brand/10 text-brand font-bold' : 'text-muted-foreground'
       )}
     >
-      <Link href={href}>{label}</Link>
+      <Link href={href}>
+        <Icon
+          className={cn(
+            'h-6 w-6 transition-transform duration-200',
+            isActive ? 'scale-110 stroke-[2.5px]' : 'stroke-[1.5px]'
+          )}
+        />
+        <span className="text-xs">{label}</span>
+
+        {isActive && (
+          <div
+            className={cn(
+              'bg-brand absolute',
+              'bottom-0 left-1/2 h-1 w-1/2 -translate-x-1/2 rounded-t-full',
+              'md:top-1/2 md:left-0 md:h-1/2 md:w-1 md:translate-x-0 md:-translate-y-1/2 md:rounded-t-none md:rounded-r-full'
+            )}
+          />
+        )}
+      </Link>
     </Button>
   );
 };

--- a/fe/src/components/layout/Footer.tsx
+++ b/fe/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="bg-background z-10 h-16 w-full border-t py-2">
+    <footer className="bg-background border-border/50 z-10 h-16 w-full border-t py-2 shadow-[0_-1px_12px_rgba(0,0,0,0.03)]">
       <div className="flex h-full items-center justify-center">
         <p className="text-muted-foreground text-center text-xs">
           &copy; {new Date().getFullYear()} Spenny. All rights reserved.

--- a/fe/src/components/layout/Header.tsx
+++ b/fe/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import GuestModeNotice from '../common/GuestModeNotice';
 import Image from 'next/image';
 import Link from 'next/link';
 import ProfilePanelTrigger from '../common/ProfilePanelTrigger';
+import { cn } from '@/lib/utils';
 import { useAuth } from '@/providers/AuthProvider';
 
 function HeaderRightSkeleton() {
@@ -14,28 +15,64 @@ const Header = () => {
   const { profile, isLoading } = useAuth();
   const isGuest = !!profile?.is_guest;
 
+  // 오늘 날짜 포맷팅
+  const today = new Intl.DateTimeFormat('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(new Date());
+
   return (
-    <header className="bg-background fixed top-0 z-10 flex h-16 w-full items-center justify-between border-b p-2">
-      <h1 className="shrink-0 px-2 pt-1">
-        <Link href="/">
-          <Image
-            src="/logo_text.svg"
-            alt="Spenny"
-            width={160}
-            height={80}
-            draggable="false"
-            className="h-auto w-32 md:w-40"
-            priority
-          />
-        </Link>
-      </h1>
-      {isLoading ? (
-        <HeaderRightSkeleton />
-      ) : isGuest ? (
-        <GuestModeNotice />
-      ) : (
-        <ProfilePanelTrigger />
+    <header
+      className={cn(
+        'fixed top-0 z-10 flex h-16 w-full items-center justify-between p-2 shadow-sm',
+        'bg-background/80 backdrop-blur-lg',
+        'md:px-4'
       )}
+    >
+      <div className="flex items-center gap-4">
+        <h1 className="shrink-0 px-2 pt-1">
+          <Link href="/">
+            <Image
+              src="/logo_text.svg"
+              alt="Spenny"
+              width={160}
+              height={80}
+              draggable="false"
+              className="h-auto w-32 md:w-36"
+              priority
+            />
+          </Link>
+        </h1>
+      </div>
+
+      <div className="flex items-center gap-3 md:gap-4">
+        {!isLoading && !isGuest && profile?.nickname && (
+          <div className="hidden flex-col items-end gap-1 md:flex">
+            <span className="text-brand text-xs leading-none font-semibold">
+              {today}
+            </span>
+            <span className="text-foreground text-sm leading-none font-bold">
+              {profile.nickname}님
+            </span>
+          </div>
+        )}
+
+        {/* 세로 구분선 */}
+        {!isLoading && !isGuest && (
+          <div className="bg-border hidden h-6 w-px md:block" />
+        )}
+
+        <div className="flex items-center">
+          {isLoading ? (
+            <HeaderRightSkeleton />
+          ) : isGuest ? (
+            <GuestModeNotice />
+          ) : (
+            <ProfilePanelTrigger />
+          )}
+        </div>
+      </div>
     </header>
   );
 };

--- a/fe/src/components/layout/Header.tsx
+++ b/fe/src/components/layout/Header.tsx
@@ -19,12 +19,12 @@ const Header = () => {
       <h1 className="shrink-0 px-2 pt-1">
         <Link href="/">
           <Image
-            src="/logo_horizontal.svg"
+            src="/logo_text.svg"
             alt="Spenny"
-            width={180}
+            width={160}
             height={80}
             draggable="false"
-            className="h-auto w-36 md:w-[180px]"
+            className="h-auto w-32 md:w-40"
             priority
           />
         </Link>

--- a/fe/src/components/layout/Header.tsx
+++ b/fe/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ const Header = () => {
   return (
     <header
       className={cn(
-        'fixed top-0 z-10 flex h-16 w-full items-center justify-between p-2 shadow-sm',
+        'border-border/50 fixed top-0 z-10 flex h-16 w-full items-center justify-between border-b p-2 shadow-[0_1px_12px_rgba(0,0,0,0.03)]',
         'bg-background/80 backdrop-blur-lg',
         'md:px-4'
       )}

--- a/fe/src/components/layout/Navigation.tsx
+++ b/fe/src/components/layout/Navigation.tsx
@@ -19,7 +19,7 @@ const Navigation = () => {
   return (
     <nav
       className={cn(
-        'bg-background fixed z-50 border px-2 py-2 shadow-xl backdrop-blur-lg',
+        'bg-background/80 fixed z-50 border px-2 py-2 shadow-xl backdrop-blur-lg',
         'bottom-0 w-full rounded-t-2xl',
         'md:top-1/2 md:left-0 md:h-fit md:w-24 md:-translate-y-1/2 md:rounded-t-none md:rounded-r-2xl md:py-4'
       )}

--- a/fe/src/components/layout/Navigation.tsx
+++ b/fe/src/components/layout/Navigation.tsx
@@ -1,26 +1,36 @@
 'use client';
 
-import NavItem from '../common/NavItem';
+import { BarChart3, Home, Repeat, Wallet } from 'lucide-react';
+
+import NavItem from '@/components/common/NavItem';
+import { cn } from '@/lib/utils';
 import { usePathname } from 'next/navigation';
 
 const Navigation = () => {
-  const pathname = usePathname(); // 현재 경로 가져오기
+  const pathname = usePathname();
+
   const navItems = [
-    { label: '홈', href: '/' },
-    { label: '가계부', href: '/history' },
-    { label: '고정비', href: '/fixed-costs' },
-    { label: '분석', href: '/analysis' },
-    { label: '예산', href: '/budget' },
+    { label: '홈', href: '/', icon: Home },
+    { label: '고정비', href: '/fixed-costs', icon: Repeat },
+    { label: '분석', href: '/analysis', icon: BarChart3 },
+    { label: '예산', href: '/budget', icon: Wallet },
   ];
 
   return (
-    <nav className="bg-background sticky top-16 z-10 w-full border-b p-2 md:fixed md:h-full md:w-28 md:border-r">
-      <div className="flex flex-wrap items-center justify-center gap-2 text-sm md:flex-col">
+    <nav
+      className={cn(
+        'bg-background fixed z-50 border px-2 py-2 shadow-xl backdrop-blur-lg',
+        'bottom-0 w-full rounded-t-2xl',
+        'md:top-1/2 md:left-0 md:h-fit md:w-24 md:-translate-y-1/2 md:rounded-t-none md:rounded-r-2xl md:py-4'
+      )}
+    >
+      <div className="flex h-14 items-center justify-center gap-2 md:h-auto md:flex-col md:gap-4">
         {navItems.map((item) => (
           <NavItem
             key={item.href}
             label={item.label}
             href={item.href}
+            itemIcon={item.icon}
             isActive={pathname === item.href}
           />
         ))}

--- a/fe/src/components/ui/button.tsx
+++ b/fe/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] cursor-pointer aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## PR 개요
- 레이아웃 구조를 전반적으로 정리하면서, 디바이스별(모바일/데스크톱) UI 배치를 최적화했습니다.

## 변경 사항
### 1. Navigation 반응형 레이아웃 및 UI 개선
- 페이지별 아이콘 추가
- 디바이스별 배치 최적화
    - 모바일: 하단 네비게이션 바
    - 데스크톱: 좌측 사이드바
- 반응형 rounded 처리 및 활성화 인디케이터 스타일 세분화

### 2. Header 개선
- 로고를 텍스트 버전으로 변경
- 데스크톱 뷰에서 오늘 날짜 및 닉네임 표시 추가

### 3. Footer 및 페이지 레이아웃 정리
- `Footer` 위치 조정
- 각 페이지에 적용되어 있던 `min-h-screen` 제거
    - 불필요한 스크롤 발생 방지 목적

### 4. 예산 추천 다이얼로그 모바일 대응
- 다이얼로그 높이를 고정값 → `80dvh`로 변경하여 반응형 대응

## 스크린샷 (선택)
### 전체 레이아웃 (데스크탑)
| Before | After |
|------------|------------|
| <img width="933" height="731" alt="HeaderNavigationUI_desktop_before" src="https://github.com/user-attachments/assets/1a506f79-d105-43d1-b8b8-f282ab8f44e6" /> | <img width="932" height="731" alt="HeaderNavigationUI_desktop_after" src="https://github.com/user-attachments/assets/8555bc5b-5891-4745-8d94-dd6f6786b95c" /> |

### 전체 레이아웃 (모바일)
| Before | After |
|------------|------------|
| <img width="271" height="731" alt="HeaderNavigationUI_mobile_before" src="https://github.com/user-attachments/assets/f731fded-27dd-4d3b-b081-ad0d0843891a" /> | <img width="271" height="734" alt="HeaderNavigationUI_mobile_after" src="https://github.com/user-attachments/assets/f80b6151-4403-4db2-9c9c-754c56227432" /> |


## 리뷰 요청 사항
- [ ] 네비게이션이 모바일/데스크탑 뷰에서 잘 전환되는지
- [ ] 네비게이션의 각 페이지별 아이콘이 적절한지
- [ ] 헤더 데스크탑 뷰 일 때, 오늘 날짜와 닉네임 추가했는데 괜찮은지
- [ ] 각 페이지에 불필요한 스크롤 발생을 방지하기 위해 최소 높이 제한을 제거했는데 괜찮은지


## 추후 할 일
- [ ] 모바일 뷰 최적화