### PR TITLE
[refactor] floating button 디자인 수정

### DIFF
--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -39,12 +39,12 @@ export default function TransactionClient() {
 
   return (
     <>
-      <div className="bg-foreground fixed bottom-0 z-50 m-4 flex gap-4 rounded-full p-1">
+      <div className="bg-foreground fixed bottom-16 z-50 m-4 flex gap-4 rounded-full p-1">
         <ReceiptOCR />
       </div>
       <Button
         onClick={openCreate}
-        className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"
+        className="fixed right-0 bottom-16 z-50 m-4 h-20 w-20 rounded-full"
         asChild
       >
         <Plus size={20} />

--- a/fe/src/app/(app)/history/TransactionClient.tsx
+++ b/fe/src/app/(app)/history/TransactionClient.tsx
@@ -39,12 +39,10 @@ export default function TransactionClient() {
 
   return (
     <>
-      <div className="bg-foreground fixed bottom-16 z-50 m-4 flex gap-4 rounded-full p-1">
-        <ReceiptOCR />
-      </div>
+      <ReceiptOCR />
       <Button
         onClick={openCreate}
-        className="fixed right-0 bottom-16 z-50 m-4 h-20 w-20 rounded-full"
+        className="fixed right-0 bottom-16 z-50 m-4 h-16 w-16 rounded-full"
         asChild
       >
         <Plus size={20} />

--- a/fe/src/components/fixed-costs/FixedCostsAddButton.tsx
+++ b/fe/src/components/fixed-costs/FixedCostsAddButton.tsx
@@ -7,7 +7,7 @@ export default function FixedCostsAddButton({ onClick }: Props) {
   return (
     <Button
       type="button"
-      className="fixed right-0 bottom-0 z-50 m-4 h-16 w-16 rounded-full"
+      className="fixed right-0 bottom-16 z-50 m-4 h-16 w-16 rounded-full"
       onClick={onClick}
       asChild
     >

--- a/fe/src/components/transaction/ReceiptOCR.tsx
+++ b/fe/src/components/transaction/ReceiptOCR.tsx
@@ -289,8 +289,11 @@ export default function ReceiptOCR() {
     <>
       <Dialog open={open} onOpenChange={handleClose}>
         <DialogTrigger asChild>
-          <Button className="h-16 w-16 cursor-pointer rounded-full bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100">
-            {loading ? <Spinner /> : <Sparkles size={20} />}
+          <Button
+            className="fixed bottom-16 left-0 z-50 m-4 h-16 w-16 cursor-pointer rounded-full bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100"
+            asChild
+          >
+            {loading ? <Spinner /> : <Sparkles size={24} />}
           </Button>
         </DialogTrigger>
         <DialogContent

--- a/fe/src/components/transaction/ReceiptOCR.tsx
+++ b/fe/src/components/transaction/ReceiptOCR.tsx
@@ -290,7 +290,7 @@ export default function ReceiptOCR() {
       <Dialog open={open} onOpenChange={handleClose}>
         <DialogTrigger asChild>
           <Button className="h-16 w-16 cursor-pointer rounded-full bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100">
-            {loading ? <Spinner /> : <Sparkles size={12} />}
+            {loading ? <Spinner /> : <Sparkles size={20} />}
           </Button>
         </DialogTrigger>
         <DialogContent


### PR DESCRIPTION
## PR 개요
네비게이션 하단 배치에 따른 floating button 디자인 수정

## 변경사항
- 홈의 OCR버튼과 가계부 생성 버튼, 고정비 페이지의 고정비 생성 버튼 위치를  `bottom-16`으로 조정
- 버튼 내부 아이콘 크기 통일
- 버튼 사이즈 `16px` 로 통일

## 리뷰 요청 사항
- [ ] 홈과 고정비 페이지에서 floating button이 bottom navigation을 가리지 않고 표시되는지
- [ ] floating button의 크기와 내부 아이콘 크기가 일관성있는지
